### PR TITLE
Fix names of err[1-3] and add erL

### DIFF
--- a/custom_components/pitboss/binary_sensor.py
+++ b/custom_components/pitboss/binary_sensor.py
@@ -19,19 +19,25 @@ from .entity import BaseEntity
 ENTITY_DESCRIPTIONS = (
     BinarySensorEntityDescription(
         key="err1",
-        name="Error 1",
+        name="Probe 1 error",
         device_class=BinarySensorDeviceClass.PROBLEM,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     BinarySensorEntityDescription(
         key="err2",
-        name="Error 2",
+        name="Probe 2 error",
         device_class=BinarySensorDeviceClass.PROBLEM,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     BinarySensorEntityDescription(
         key="err3",
-        name="Error 3",
+        name="Probe 3 error",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    BinarySensorEntityDescription(
+        key="erL",
+        name="Startup error",
         device_class=BinarySensorDeviceClass.PROBLEM,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),


### PR DESCRIPTION
As reported in https://github.com/dknowles2/ha-pitboss/issues/23

* err[1-3] are errors with a particular meat probe
* erL is an error in the startup cycle, or a problem with the igniter staying lit. (we'll just call it a "Startup error"