### PR TITLE
Version bump

### DIFF
--- a/custom_components/pitboss/manifest.json
+++ b/custom_components/pitboss/manifest.json
@@ -65,7 +65,7 @@
     "pytboss"
   ],
   "requirements": [
-    "pytboss==2024.1.0"
+    "pytboss==2024.2.0"
   ],
-  "version": "2024.1.0"
+  "version": "2024.2.0"
 }


### PR DESCRIPTION
Updates pytboss to 2024.2.0 to fix compatibility problems with python 3.12. This should address #42