### PR TITLE
Fix an infinite loop triggered in HA 2024.10

### DIFF
--- a/custom_components/pitboss/__init__.py
+++ b/custom_components/pitboss/__init__.py
@@ -16,7 +16,6 @@ from homeassistant.core import HomeAssistant, callback
 from .const import DOMAIN, LOGGER
 from .coordinator import PitBossDataUpdateCoordinator
 
-
 PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,
     Platform.CLIMATE,
@@ -55,7 +54,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-    entry.async_on_unload(entry.add_update_listener(async_reload_entry))
 
     return True
 
@@ -65,9 +63,3 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if unloaded := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
         hass.data[DOMAIN].pop(entry.entry_id)
     return unloaded
-
-
-async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    """Reload config entry."""
-    await async_unload_entry(hass, entry)
-    await async_setup_entry(hass, entry)


### PR DESCRIPTION
This removes the `async_reload_entry` function, which doesn't seem to be needed and is causing infinite loops on upgrades to HA 2024.10

This should fix #63 