### PR TITLE
Fix support for PBL2 models

### DIFF
--- a/custom_components/pitboss/config_flow.py
+++ b/custom_components/pitboss/config_flow.py
@@ -86,6 +86,8 @@ class PitBossFlowHandler(ConfigFlow, domain=DOMAIN):
     ) -> ConfigFlowResult:
         """Show the more_info form."""
         control_board = self._device_id.split("-")[0]
+        if control_board == "PBL2":
+            control_board = "PBL3"
         models = [g.name for g in grills.get_grills(control_board=control_board)]
         if not models:
             return self.async_abort(


### PR DESCRIPTION
These grills advertise over bluetooth as "PBL2-XXXX" but the control board is registered as PBL3.

Fixes #114