### PR TITLE
Map Louisiana Black Label (LBL) prefix to PBL control board

### DIFF
--- a/custom_components/pitboss/config_flow.py
+++ b/custom_components/pitboss/config_flow.py
@@ -13,6 +13,15 @@ from pytboss import grills
 
 from .const import ALL_PROTOCOLS, DEFAULT_PROTOCOL, DOMAIN, LOGGER
 
+# Some BLE-name prefixes don't directly match a pytboss control board. Pit Boss
+# and its sibling Dansons brand Louisiana Grills sometimes advertise under a
+# prefix that differs from the control board name pytboss expects. Map those
+# prefixes to the equivalent control board so discovery can resolve a model.
+CONTROL_BOARD_ALIASES = {
+    "PBL2": "PBL3",
+    "LBL": "PBL",  # Louisiana Black Label series (verified on an LG800BL)
+}
+
 
 class PitBossFlowHandler(ConfigFlow, domain=DOMAIN):
     """Config flow for PitBoss."""
@@ -86,8 +95,7 @@ class PitBossFlowHandler(ConfigFlow, domain=DOMAIN):
     ) -> ConfigFlowResult:
         """Show the more_info form."""
         control_board = self._device_id.split("-")[0]
-        if control_board == "PBL2":
-            control_board = "PBL3"
+        control_board = CONTROL_BOARD_ALIASES.get(control_board, control_board)
         models = [g.name for g in grills.get_grills(control_board=control_board)]
         if not models:
             return self.async_abort(


### PR DESCRIPTION
## Summary

Louisiana Grills is a Dansons sibling brand of Pit Boss that shares the same control boards but advertises over BLE with brand-specific name prefixes. The manifest already discovers `LBL-*` devices, but the config flow derives the control board from the name prefix, yielding `"LBL"` — a board `pytboss` doesn't know. `grills.get_grills(control_board="LBL")` returns an empty list, so the flow aborts with `unknown_grill` right after discovery.

In other words: the grill is found, but cannot be added.

## Change

Refactor the existing `PBL2` -> `PBL3` special case into a small `CONTROL_BOARD_ALIASES` table and add `LBL` -> `PBL`. The Black Label series uses the WiFi+BT `PBL` board on the Pit Boss side.

```python
CONTROL_BOARD_ALIASES = {
    "PBL2": "PBL3",
    "LBL": "PBL",  # Louisiana Black Label series (verified on an LG800BL)
}
...
control_board = self._device_id.split("-")[0]
control_board = CONTROL_BOARD_ALIASES.get(control_board, control_board)
```

## Verification

Tested end to end on a **Louisiana Grills 800 Black Label (LG800BL)**:

- Confirmed independently with `pytboss` over BLE that the grill connects with model `PBV4PS2` (a `PBL`-board model) — read firmware `0.2.3` and a live state stream (probe/grill/smoker temps, error flags).
- With this patch, the config flow now lists the `PBL` models instead of aborting, and the device adds and connects over Bluetooth (local) in Home Assistant.

Because the Black Label line (800/1000/1200) shares the one control board, this single mapping covers the whole series.

## Not covered

Other Louisiana prefixes the manifest matches (`LFS`) and the Pit Boss `PBX1` prefix also resolve to unknown boards and still abort. I didn't map them since I can't verify them against hardware — happy to add them in a follow-up if someone can confirm the correct boards.

`ruff check` and `ruff format --check` pass.