### PR TITLE
fix: wrap PitBoss constructor in executor to avoid blocking I/O (#210)

### DIFF
--- a/custom_components/pitboss/__init__.py
+++ b/custom_components/pitboss/__init__.py
@@ -102,7 +102,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     else:
         raise ValueError(f"Unknown protocol: {protocol}")
 
-    pitboss = api.PitBoss(conn, model, password=password)
+    pitboss = await hass.async_add_executor_job(
+        lambda: api.PitBoss(conn, model, password=password)
+    )
     device_info = DeviceInfo(
         identifiers={(DOMAIN, device_id)},
         name=device_id,


### PR DESCRIPTION
## Problem

The `api.PitBoss()` constructor loads grill spec/model JSON files from disk synchronously. When called inside an `async` function on the HA event loop, this triggers **blocking I/O warnings** from Home Assistant.

A user reported the fix in #210:
> Line 105: Change `pitboss = api.PitBoss(...)` to `pitboss = await hass.async_add_executor_job(lambda: api.PitBoss(...))`

## Fix

Wrap the `api.PitBoss()` constructor in `hass.async_add_executor_job()` so that the synchronous file I/O is offloaded to a thread-pool executor rather than running on the asyncio event loop.

## Changes

- `custom_components/pitboss/__init__.py`: Wrap `api.PitBoss()` construction in `async_add_executor_job`

Fixes #210