### PR TITLE
fix: always poll grill state on each update interval (#123)

### DIFF
--- a/custom_components/pitboss/coordinator.py
+++ b/custom_components/pitboss/coordinator.py
@@ -61,14 +61,12 @@ class PitBossDataUpdateCoordinator(DataUpdateCoordinator[StateDict]):
         except NotConnectedError as ex:
             raise UpdateFailed("Grill not connected") from ex
 
-        if self.data is None:
-            # We haven't received a WebSocket push. Try to manually fetch the state.
-            try:
-                return await self.api.get_state()
-            except NotConnectedError as ex:
-                raise UpdateFailed("Grill not connected") from ex
-            except RPCError as ex:
-                raise UpdateFailed(str(ex)) from ex
-
-        # Return the last data received from the WebSocket push.
-        return self.data
+        # Always fetch the current state to ensure sensors stay up-to-date.
+        # Relying solely on push notifications means sensors can go stale after
+        # a reconnect if push notifications stop being delivered.
+        try:
+            return await self.api.get_state()
+        except NotConnectedError as ex:
+            raise UpdateFailed("Grill not connected") from ex
+        except RPCError as ex:
+            raise UpdateFailed(str(ex)) from ex


### PR DESCRIPTION
## Problem

Sensors stop updating after a reconnect (or sometimes from the start). The issue is in the coordinator's `_async_update_data` method:

```python
if self.data is None:
    return await self.api.get_state()

# Return the last data received from the WebSocket push.
return self.data
```

Once `self.data` has been set (from the initial state fetch or the first push notification), the coordinator stops polling the grill for fresh data and relies **entirely** on push notifications (WebSocket or BLE). If push notifications stop being delivered after a reconnect, sensors are stuck showing stale values.

## Fix

Always call `api.get_state()` on each coordinator update cycle regardless of whether `self.data` is set. Push-based updates via `_on_state_update` still fire between polling intervals for lower latency, but the periodic poll (every 30 seconds) ensures sensors always refresh.

## Changes

- `custom_components/pitboss/coordinator.py`: Remove the early-return-if-data-exists branch; always fetch state from the grill

Fixes #123