### PR TITLE
fix: restore device_class/entity_category on binary sensors

### DIFF
--- a/custom_components/pitboss/binary_sensor.py
+++ b/custom_components/pitboss/binary_sensor.py
@@ -1,6 +1,7 @@
 """Binary sensor platform for PitBoss."""
 
 from __future__ import annotations
+from dataclasses import dataclass
 from typing import Literal
 
 from homeassistant.components.binary_sensor import (
@@ -18,6 +19,7 @@ from .coordinator import PitBossDataUpdateCoordinator
 from .entity import BaseEntity
 
 
+@dataclass(frozen=True, kw_only=True)
 class PBBinarySensorEntityDescription(BinarySensorEntityDescription):
     """Describes PitBoss binary sensor entity."""
 
@@ -33,8 +35,8 @@ class PBBinarySensorEntityDescription(BinarySensorEntityDescription):
         "noPellets",
         "motorState",
     ]
-    device_class = BinarySensorDeviceClass.PROBLEM
-    entity_category = EntityCategory.DIAGNOSTIC
+    device_class: BinarySensorDeviceClass | None = BinarySensorDeviceClass.PROBLEM
+    entity_category: EntityCategory | None = EntityCategory.DIAGNOSTIC
 
 
 ENTITY_DESCRIPTIONS = (


### PR DESCRIPTION
## Problem

`PBBinarySensorEntityDescription` subclasses `BinarySensorEntityDescription`
(a dataclass) but is **not** decorated with `@dataclass`. As a result the
class-level attributes

```python
device_class = BinarySensorDeviceClass.PROBLEM
entity_category = EntityCategory.DIAGNOSTIC
```

are shadowed by the parent dataclass `__init__`, which sets both instance
attributes to their field defaults (`None`). Every error binary sensor
(`err1`, `err2`, `err3`, `erL`, `highTempErr`, `fanErr`, `hotErr`,
`motorErr`, `noPellets`) therefore ends up with **no** device class and is
**not** placed in the diagnostic category. Only `motorState` is unaffected,
because it passes `device_class` as a constructor argument.

Verified against a live install via the entity registry:

```
probe_1_error -> original_device_class: null    (expected: problem)
auger         -> original_device_class: running (ok, passed as kwarg)
```

## Fix

Decorate the description as `@dataclass(frozen=True, kw_only=True)` and
declare `device_class` / `entity_category` as fields with defaults, matching
the pattern already used in `sensor.py` and `number.py`. Per-instance
overrides (e.g. `motorState` using `RUNNING` / `entity_category=None`)
continue to work.

## Changes

- `custom_components/pitboss/binary_sensor.py`: add `@dataclass` decorator and
  turn `device_class` / `entity_category` into proper dataclass fields.

---

_Note: this PR was originally opened with a second commit wrapping
`api.PitBoss()` in the executor, but that is already covered by #275, so it
has been dropped to keep this PR focused on the binary-sensor fix._
