### PR TITLE
Group homeassistant and pytest-homeassistant-custom-component in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,11 @@ updates:
     directory: "/"
     schedule:
       interval: daily
+    groups:
+      homeassistant:
+        patterns:
+          - "homeassistant"
+          - "pytest-homeassistant-custom-component"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Summary

Follow-up to #293. `pytest-homeassistant-custom-component` is released in lockstep with an exact `homeassistant` pin (every release note says "homeassistant version: X"), so bumping either package independently leaves the other version incompatible and CI red. This is exactly what happened with #288 and #289: two separate Dependabot PRs that each failed CI on their own and deadlocked each other.

- Add a Dependabot `groups` entry for the `pip` ecosystem that bundles `homeassistant` and `pytest-homeassistant-custom-component` updates into a single PR whenever either has a new version.

Note: grouping guarantees they land together, not that the combined bump is automatically CI-green — transitive manifest-dependency gaps (like the `serialx`/`aioesphomeapi` ones fixed in #293) can still surface and need a manual follow-up.

## Test plan

- [ ] Next Dependabot run picks up the `homeassistant` group and opens a single combined PR for both packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01U3z7q9Ng4NxqUASULvLW7G)_