### PR TITLE
CI: auto-sync manifest.json pytboss version on Dependabot bumps

### DIFF
--- a/.github/workflows/sync-manifest-version.yml
+++ b/.github/workflows/sync-manifest-version.yml
@@ -1,0 +1,37 @@
+name: Sync manifest pytboss version
+
+on:
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "requirements.txt"
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    # Only Dependabot PRs touch requirements.txt without a matching manifest
+    # bump; run for its branches so a version drift gets fixed automatically.
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+      - uses: actions/setup-python@v7
+        with:
+          python-version-file: ".python-version"
+      - name: Sync manifest.json to requirements.txt
+        run: python scripts/sync_manifest_version.py
+      - name: Commit if changed
+        run: |
+          if git diff --quiet; then
+            echo "Already in sync"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add custom_components/pitboss/manifest.json
+          git commit -m "Sync manifest.json pytboss version"
+          git push

--- a/scripts/sync_manifest_version.py
+++ b/scripts/sync_manifest_version.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Sync the pinned `pytboss` version from requirements.txt into manifest.json.
+
+Keeps custom_components/pitboss/manifest.json's "requirements" entry aligned
+with requirements.txt so Dependabot bumps to one don't silently drift from
+the other. Exits nonzero (and leaves files unchanged) if pytboss can't be
+found in requirements.txt.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+REQUIREMENTS = ROOT / "requirements.txt"
+MANIFEST = ROOT / "custom_components" / "pitboss" / "manifest.json"
+PACKAGE = "pytboss"
+
+
+def pinned_version(requirements_text: str, package: str) -> str:
+    match = re.search(rf"^{re.escape(package)}==([^\s]+)$", requirements_text, re.MULTILINE)
+    if not match:
+        raise SystemExit(f"Could not find pinned '{package}==' line in {REQUIREMENTS}")
+    return match.group(1)
+
+
+def main() -> int:
+    version = pinned_version(REQUIREMENTS.read_text(), PACKAGE)
+    manifest = json.loads(MANIFEST.read_text())
+
+    updated = [
+        f"{PACKAGE}=={version}" if req.split("==")[0] == PACKAGE else req
+        for req in manifest["requirements"]
+    ]
+
+    if updated == manifest["requirements"]:
+        print(f"manifest.json already in sync ({PACKAGE}=={version})")
+        return 0
+
+    manifest["requirements"] = updated
+    MANIFEST.write_text(json.dumps(manifest, indent=2) + "\n")
+    print(f"Updated manifest.json requirements to {PACKAGE}=={version}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Adds `scripts/sync_manifest_version.py` to keep `custom_components/pitboss/manifest.json`'s pinned `pytboss` requirement in sync with `requirements.txt`.

New workflow `sync-manifest-version.yml` runs it on Dependabot PRs that touch `requirements.txt` and pushes a fixup commit if manifest.json is out of sync — runs before `auto-merge.yml` merges the PR.

Manually verified the script detects/fixes drift and no-ops when already in sync.