### PR TITLE
Improve test coverage across the pitboss integration

### DIFF
--- a/custom_components/pitboss/climate.py
+++ b/custom_components/pitboss/climate.py
@@ -107,7 +107,9 @@ class GrillClimate(BaseEntity, ClimateEntity):
         if hvac_mode == HVACMode.OFF:
             await self.async_turn_off()
         elif hvac_mode == HVACMode.HEAT:
-            LOGGER.warn("For safety reasons, the grill cannot be turned on remotely.")
+            LOGGER.warning(
+                "For safety reasons, the grill cannot be turned on remotely."
+            )
 
     @property
     def hvac_mode(self) -> HVACMode | None:

--- a/custom_components/pitboss/light.py
+++ b/custom_components/pitboss/light.py
@@ -29,6 +29,7 @@ class GrillLight(BaseEntity, LightEntity):
     """PitBoss light class."""
 
     _attr_supported_color_modes = {ColorMode.ONOFF}  # noqa: RUF012
+    _attr_color_mode = ColorMode.ONOFF
 
     def __init__(
         self, coordinator: PitBossDataUpdateCoordinator, entity_unique_id: str

--- a/custom_components/pitboss/switch.py
+++ b/custom_components/pitboss/switch.py
@@ -64,7 +64,7 @@ class PowerSwitch(BaseSwitchEntity):
 
     async def async_turn_on(self, **_: Any) -> None:
         """Turn on the switch."""
-        LOGGER.warn("For safety reasons, the grill cannot be turned on remotely.")
+        LOGGER.warning("For safety reasons, the grill cannot be turned on remotely.")
 
     async def async_turn_off(self, **_: Any) -> None:
         """Turn off the switch."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,14 +1,38 @@
 from collections.abc import Awaitable, Callable, Generator
+from typing import TypeVar
 from unittest.mock import Mock, patch
 
 import pytest
 from homeassistant.const import CONF_DEVICE_ID, CONF_MODEL, CONF_PASSWORD, CONF_PROTOCOL
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_platform as ep
+from homeassistant.helpers.entity import Entity
 from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM, UnitSystem
 from pytboss.grills import Grill, get_grill
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.pitboss.const import DOMAIN, PROTOCOL_WSS
+
+_EntityT = TypeVar("_EntityT", bound=Entity)
+
+
+def get_entity(
+    hass: HomeAssistant,
+    platform_domain: str,
+    entity_id: str,
+    entity_type: type[_EntityT],
+) -> _EntityT:
+    """Look up a live entity object bypassing the HA state machine.
+
+    Useful for exercising code paths (like a falsy-data fallback) that HA's
+    own state-write pipeline skips once an entity is marked unavailable.
+    """
+    for platform in ep.async_get_platforms(hass, DOMAIN):
+        if platform.domain == platform_domain:
+            entity = platform.entities[entity_id]
+            assert isinstance(entity, entity_type)
+            return entity
+    raise AssertionError(f"{platform_domain} platform not found")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -1,0 +1,58 @@
+from collections.abc import Awaitable, Callable
+
+import pytest
+from conftest import get_entity
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.pitboss.binary_sensor import ENTITY_DESCRIPTIONS, BinarySensor
+from custom_components.pitboss.const import DOMAIN
+from custom_components.pitboss.coordinator import PitBossDataUpdateCoordinator
+
+pytestmark = pytest.mark.parametrize("model", ["PBV4PS2"])
+
+
+def _entity_id(name: str) -> str:
+    return f"binary_sensor.mygrill_{name.lower().replace(' ', '_')}"
+
+
+async def test_creates_all_entities(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+) -> None:
+    await mock_add_config_entry()
+    for description in ENTITY_DESCRIPTIONS:
+        assert isinstance(description.name, str)
+        entity_id = _entity_id(description.name)
+        assert hass.states.get(entity_id) is not None, entity_id
+
+
+async def test_is_on_no_data(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+) -> None:
+    await mock_add_config_entry()
+    state = hass.states.get(_entity_id("Probe 1 error"))
+    assert state is not None
+    assert state.state == "unavailable"
+
+    entity = get_entity(
+        hass, "binary_sensor", _entity_id("Probe 1 error"), BinarySensor
+    )
+    assert entity.is_on is None
+
+
+async def test_is_on_with_data(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+) -> None:
+    entry = await mock_add_config_entry()
+    coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator.async_set_updated_data({"err1": True, "motorState": False})
+    await hass.async_block_till_done()
+    probe_1_error = hass.states.get(_entity_id("Probe 1 error"))
+    auger = hass.states.get(_entity_id("Auger"))
+    assert probe_1_error is not None
+    assert auger is not None
+    assert probe_1_error.state == "on"
+    assert auger.state == "off"

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -1,8 +1,18 @@
 from collections.abc import Awaitable, Callable
+from unittest.mock import Mock
 
 import pytest
+from conftest import get_entity
+from homeassistant.components.climate.const import HVACAction, HVACMode
 from homeassistant.core import HomeAssistant
+from pytboss.grills import StateDict
 from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.pitboss.climate import GrillClimate
+from custom_components.pitboss.const import DOMAIN
+from custom_components.pitboss.coordinator import PitBossDataUpdateCoordinator
+
+ENTITY_ID = "climate.mygrill_grill_temperature"
 
 
 @pytest.mark.parametrize("model,want", [("PBV4PS2", 130), ("PB2180LK", 180)])
@@ -12,7 +22,7 @@ async def test_min_temp(
     want: float,
 ) -> None:
     await mock_add_config_entry()
-    temps = hass.states.get("climate.mygrill_grill_temperature")
+    temps = hass.states.get(ENTITY_ID)
     assert temps is not None
     assert temps.attributes["min_temp"] == want
 
@@ -24,6 +34,190 @@ async def test_max_temp(
     want: float,
 ) -> None:
     await mock_add_config_entry()
-    temps = hass.states.get("climate.mygrill_grill_temperature")
+    temps = hass.states.get(ENTITY_ID)
     assert temps is not None
     assert temps.attributes["max_temp"] == want
+
+
+@pytest.mark.parametrize("model", ["PBV4PS2"])
+async def test_target_temperature_step(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+) -> None:
+    entry = await mock_add_config_entry()
+    coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+
+    coordinator.async_set_updated_data({"isFahrenheit": True})
+    await hass.async_block_till_done()
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.attributes["target_temp_step"] == 5.0
+
+    coordinator.async_set_updated_data({"isFahrenheit": False})
+    await hass.async_block_till_done()
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.attributes["target_temp_step"] == 1.0
+
+
+@pytest.mark.parametrize("model", ["PBV4PS2"])
+async def test_current_and_target_temperature(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+) -> None:
+    entry = await mock_add_config_entry()
+    coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+
+    # No data yet: entity is unavailable, so these attributes are absent.
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.attributes.get("current_temperature") is None
+    assert state.attributes.get("temperature") is None
+
+    coordinator.async_set_updated_data(
+        {"grillTemp": 225, "grillSetTemp": 250, "isFahrenheit": True}
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.attributes["current_temperature"] == 225.0
+    assert state.attributes["temperature"] == 250.0
+
+
+@pytest.mark.parametrize("model", ["PBV4PS2"])
+async def test_set_temperature_noop_without_temperature_kwarg(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+    mock_pitboss: Mock,
+) -> None:
+    await mock_add_config_entry()
+    entity = get_entity(hass, "climate", ENTITY_ID, GrillClimate)
+    await entity.async_set_temperature()
+    mock_pitboss.set_grill_temperature.assert_not_awaited()
+
+
+@pytest.mark.parametrize("model", ["PBV4PS2"])
+async def test_set_hvac_mode_heat_is_a_safety_noop(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+    mock_pitboss: Mock,
+) -> None:
+    entry = await mock_add_config_entry()
+    coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator.async_set_updated_data({"moduleIsOn": False})
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        "climate",
+        "set_hvac_mode",
+        {"entity_id": ENTITY_ID, "hvac_mode": "heat"},
+        blocking=True,
+    )
+    mock_pitboss.turn_grill_off.assert_not_awaited()
+
+
+@pytest.mark.parametrize("model", ["PBV4PS2"])
+async def test_set_temperature(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+    mock_pitboss: Mock,
+) -> None:
+    entry = await mock_add_config_entry()
+    coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator.async_set_updated_data({"moduleIsOn": True, "isFahrenheit": True})
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        "climate",
+        "set_temperature",
+        {"entity_id": ENTITY_ID, "temperature": 275},
+        blocking=True,
+    )
+    mock_pitboss.set_grill_temperature.assert_awaited_once_with(275)
+
+
+@pytest.mark.parametrize("model", ["PBV4PS2"])
+async def test_turn_off(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+    mock_pitboss: Mock,
+) -> None:
+    entry = await mock_add_config_entry()
+    coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator.async_set_updated_data({"moduleIsOn": True})
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        "climate",
+        "set_hvac_mode",
+        {"entity_id": ENTITY_ID, "hvac_mode": "off"},
+        blocking=True,
+    )
+    mock_pitboss.turn_grill_off.assert_awaited_once()
+    mock_pitboss.set_grill_temperature.assert_awaited_once_with(130)
+
+
+@pytest.mark.parametrize("model", ["PBV4PS2"])
+async def test_hvac_mode(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+) -> None:
+    entry = await mock_add_config_entry()
+    coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+
+    # No data yet: entity is unavailable.
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == "unavailable"
+
+    coordinator.async_set_updated_data({"moduleIsOn": True})
+    await hass.async_block_till_done()
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == HVACMode.HEAT.value
+
+    coordinator.async_set_updated_data({"moduleIsOn": False})
+    await hass.async_block_till_done()
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == HVACMode.OFF.value
+
+
+@pytest.mark.parametrize(
+    "data,want",
+    [
+        ({"hotState": True, "moduleIsOn": True}, HVACAction.HEATING),
+        (
+            {"hotState": False, "moduleIsOn": False, "fanState": True},
+            HVACAction.COOLING,
+        ),
+        ({"hotState": False, "moduleIsOn": True, "fanState": True}, HVACAction.FAN),
+        ({"hotState": False, "moduleIsOn": False, "fanState": False}, HVACAction.OFF),
+        ({"hotState": False, "moduleIsOn": True, "fanState": False}, HVACAction.IDLE),
+    ],
+)
+@pytest.mark.parametrize("model", ["PBV4PS2"])
+async def test_hvac_action(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+    data: StateDict,
+    want: HVACAction,
+) -> None:
+    entry = await mock_add_config_entry()
+    coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator.async_set_updated_data(data)
+    await hass.async_block_till_done()
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.attributes["hvac_action"] == want.value
+
+
+@pytest.mark.parametrize("model", ["PBV4PS2"])
+async def test_hvac_mode_and_action_none_without_data(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+) -> None:
+    await mock_add_config_entry()
+    entity = get_entity(hass, "climate", ENTITY_ID, GrillClimate)
+    assert entity.hvac_mode is None
+    assert entity.hvac_action is None

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,200 @@
+from unittest.mock import Mock
+
+import pytest
+from bleak.backends.device import BLEDevice
+from homeassistant import config_entries
+from homeassistant.components.bluetooth import BluetoothServiceInfoBleak
+from homeassistant.const import CONF_DEVICE_ID, CONF_MODEL, CONF_PASSWORD, CONF_PROTOCOL
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.pitboss.const import DOMAIN, PROTOCOL_WSS
+
+
+def _bluetooth_service_info(name: str) -> BluetoothServiceInfoBleak:
+    return BluetoothServiceInfoBleak(
+        name=name,
+        address="AA:BB:CC:DD:EE:FF",
+        rssi=-60,
+        manufacturer_data={},
+        service_data={},
+        service_uuids=[],
+        source="local",
+        device=BLEDevice(address="AA:BB:CC:DD:EE:FF", name=name, details=None),
+        advertisement=None,
+        connectable=True,
+        time=0.0,
+        tx_power=None,
+    )
+
+
+async def test_user_flow_shows_form(hass: HomeAssistant) -> None:
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+
+async def test_user_flow_unknown_grill_aborts(hass: HomeAssistant) -> None:
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_DEVICE_ID: "ZZZZZZZZ-ABC123"}
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "unknown_grill"
+
+
+async def test_user_flow_shows_more_info_form(hass: HomeAssistant) -> None:
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_DEVICE_ID: "PBL-ABC123"}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "more_info"
+
+
+async def test_user_flow_creates_entry(hass: HomeAssistant) -> None:
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_DEVICE_ID: "PBL-ABC123"}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_MODEL: "PBV4PS2",
+            CONF_PASSWORD: "hunter2",
+            CONF_PROTOCOL: PROTOCOL_WSS,
+        },
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "PBL-ABC123"
+    assert result["data"] == {
+        CONF_DEVICE_ID: "PBL-ABC123",
+        CONF_MODEL: "PBV4PS2",
+        CONF_PASSWORD: "hunter2",
+        CONF_PROTOCOL: PROTOCOL_WSS,
+    }
+
+
+async def test_user_flow_pbl2_maps_to_pbl3_control_board(
+    hass: HomeAssistant,
+) -> None:
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_DEVICE_ID: "PBL2-ABC123"}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "more_info"
+    data_schema = result["data_schema"]
+    assert data_schema is not None
+    models = data_schema.schema[CONF_MODEL].container
+    assert len(models) > 0
+
+
+async def test_user_flow_already_configured_aborts(hass: HomeAssistant) -> None:
+    existing_entry = MockConfigEntry(
+        title="title",
+        domain=DOMAIN,
+        data={
+            CONF_DEVICE_ID: "PBL-ABC123",
+            CONF_MODEL: "PBV4PS2",
+            CONF_PASSWORD: "asdfasdf",
+            CONF_PROTOCOL: PROTOCOL_WSS,
+        },
+        unique_id="pbl-abc123",
+    )
+    existing_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_DEVICE_ID: "PBL-ABC123"}
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_bluetooth_flow_shows_confirm(hass: HomeAssistant) -> None:
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_BLUETOOTH},
+        data=_bluetooth_service_info("PBL-ABC123"),
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "bluetooth_confirm"
+    assert result["description_placeholders"] == {"name": "PBL-ABC123"}
+
+
+async def test_bluetooth_flow_confirm_advances_to_more_info(
+    hass: HomeAssistant,
+) -> None:
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_BLUETOOTH},
+        data=_bluetooth_service_info("PBL-ABC123"),
+    )
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "more_info"
+
+
+def _reconfigure_entry() -> MockConfigEntry:
+    return MockConfigEntry(
+        title="title",
+        domain=DOMAIN,
+        data={
+            CONF_DEVICE_ID: "PBL-ABC123",
+            CONF_MODEL: "PBV4PS2",
+            CONF_PASSWORD: "oldpw",
+            CONF_PROTOCOL: PROTOCOL_WSS,
+        },
+        unique_id="pbl-abc123",
+    )
+
+
+async def test_reconfigure_flow_shows_prefilled_form(hass: HomeAssistant) -> None:
+    entry = _reconfigure_entry()
+    entry.add_to_hass(hass)
+
+    result = await entry.start_reconfigure_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+
+
+@pytest.mark.parametrize("model", ["PBV4PS2"])
+async def test_reconfigure_flow_updates_entry(
+    hass: HomeAssistant,
+    mock_wss_conn: Mock,
+    mock_pitboss: Mock,
+) -> None:
+    # Reconfiguring reloads the entry, so the WSS connection and API need to
+    # be mocked (keeping the protocol as WSS) for the reload to succeed
+    # without a real network connection.
+    mock_pitboss.get_state.return_value = {}
+    entry = _reconfigure_entry()
+    entry.add_to_hass(hass)
+
+    result = await entry.start_reconfigure_flow(hass)
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_MODEL: "PBV4PS2",
+            CONF_PASSWORD: "newpw",
+            CONF_PROTOCOL: PROTOCOL_WSS,
+        },
+    )
+    await hass.async_block_till_done()
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert entry.data[CONF_PASSWORD] == "newpw"

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,0 +1,107 @@
+from unittest.mock import Mock
+
+import pytest
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.update_coordinator import UpdateFailed
+from pytboss.exceptions import GrillUnavailable, NotConnectedError, RPCError
+
+from custom_components.pitboss.coordinator import PitBossDataUpdateCoordinator
+
+pytestmark = pytest.mark.parametrize("model", ["PBV4PS2"])
+
+
+@pytest.fixture
+def coordinator(
+    hass: HomeAssistant, mock_pitboss: Mock
+) -> PitBossDataUpdateCoordinator:
+    return PitBossDataUpdateCoordinator(hass, DeviceInfo(), mock_pitboss)
+
+
+async def test_async_setup_subscribes_and_starts(
+    coordinator: PitBossDataUpdateCoordinator, mock_pitboss: Mock
+) -> None:
+    await coordinator._async_setup()
+    mock_pitboss.subscribe_state.assert_awaited_once_with(coordinator._on_state_update)
+    mock_pitboss.start.assert_awaited_once()
+    assert coordinator._api_started is True
+
+
+async def test_on_state_update_sets_data(
+    coordinator: PitBossDataUpdateCoordinator,
+) -> None:
+    await coordinator._on_state_update({"grillTemp": 200})
+    assert coordinator.data == {"grillTemp": 200}
+
+
+async def test_start_api_raises_update_failed_on_grill_unavailable(
+    coordinator: PitBossDataUpdateCoordinator, mock_pitboss: Mock
+) -> None:
+    mock_pitboss.start.side_effect = GrillUnavailable("nope")
+    with pytest.raises(UpdateFailed):
+        await coordinator._start_api()
+    assert coordinator._api_started is False
+
+
+async def test_async_update_data_starts_api_if_not_started(
+    coordinator: PitBossDataUpdateCoordinator, mock_pitboss: Mock
+) -> None:
+    mock_pitboss.is_connected.return_value = True
+    mock_pitboss.get_state.return_value = {"grillTemp": 100}
+    assert coordinator._api_started is False
+
+    data = await coordinator._async_update_data()
+
+    mock_pitboss.start.assert_awaited_once()
+    assert coordinator._api_started is True
+    assert data == {"grillTemp": 100}
+
+
+async def test_async_update_data_raises_when_not_connected(
+    coordinator: PitBossDataUpdateCoordinator, mock_pitboss: Mock
+) -> None:
+    coordinator._api_started = True
+    mock_pitboss.is_connected.return_value = False
+    with pytest.raises(UpdateFailed):
+        await coordinator._async_update_data()
+
+
+async def test_async_update_data_raises_when_ping_not_connected(
+    coordinator: PitBossDataUpdateCoordinator, mock_pitboss: Mock
+) -> None:
+    coordinator._api_started = True
+    mock_pitboss.is_connected.return_value = True
+    mock_pitboss.ping.side_effect = NotConnectedError("nope")
+    with pytest.raises(UpdateFailed):
+        await coordinator._async_update_data()
+
+
+async def test_async_update_data_raises_when_get_state_not_connected(
+    coordinator: PitBossDataUpdateCoordinator, mock_pitboss: Mock
+) -> None:
+    coordinator._api_started = True
+    mock_pitboss.is_connected.return_value = True
+    mock_pitboss.get_state.side_effect = NotConnectedError("nope")
+    with pytest.raises(UpdateFailed):
+        await coordinator._async_update_data()
+
+
+async def test_async_update_data_raises_on_rpc_error(
+    coordinator: PitBossDataUpdateCoordinator, mock_pitboss: Mock
+) -> None:
+    coordinator._api_started = True
+    mock_pitboss.is_connected.return_value = True
+    mock_pitboss.get_state.side_effect = RPCError("boom")
+    with pytest.raises(UpdateFailed):
+        await coordinator._async_update_data()
+
+
+async def test_async_update_data_success(
+    coordinator: PitBossDataUpdateCoordinator, mock_pitboss: Mock
+) -> None:
+    coordinator._api_started = True
+    mock_pitboss.is_connected.return_value = True
+    mock_pitboss.get_state.return_value = {"grillTemp": 225}
+    data = await coordinator._async_update_data()
+    mock_pitboss.ping.assert_awaited_once_with(timeout=10.0)
+    assert data == {"grillTemp": 225}

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,142 @@
+import asyncio
+from unittest.mock import Mock, patch
+
+import pytest
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import CONF_DEVICE_ID, CONF_MODEL, CONF_PASSWORD, CONF_PROTOCOL
+from homeassistant.core import HomeAssistant
+from pytboss.exceptions import GrillUnavailable
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.pitboss.const import DOMAIN, PROTOCOL_BLE, PROTOCOL_WSS
+
+pytestmark = pytest.mark.parametrize("model", ["PBV4PS2"])
+
+
+async def test_setup_entry_unknown_protocol_errors(
+    hass: HomeAssistant, mock_wss_conn: Mock, mock_pitboss: Mock
+) -> None:
+    entry = MockConfigEntry(
+        title="title",
+        domain=DOMAIN,
+        data={
+            CONF_DEVICE_ID: "mygrill",
+            CONF_MODEL: "PBV4PS2",
+            CONF_PASSWORD: "asdfasdf",
+            CONF_PROTOCOL: "bogus",
+        },
+        unique_id="mygrillid",
+    )
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    assert entry.state is ConfigEntryState.SETUP_ERROR
+
+
+async def test_setup_entry_not_ready_disconnects_and_stops(
+    hass: HomeAssistant, mock_wss_conn: Mock, mock_pitboss: Mock
+) -> None:
+    mock_pitboss.start.side_effect = GrillUnavailable("nope")
+    entry = MockConfigEntry(
+        title="title",
+        domain=DOMAIN,
+        data={
+            CONF_DEVICE_ID: "mygrill",
+            CONF_MODEL: "PBV4PS2",
+            CONF_PASSWORD: "asdfasdf",
+            CONF_PROTOCOL: PROTOCOL_WSS,
+        },
+        unique_id="mygrillid",
+    )
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.SETUP_RETRY
+    mock_wss_conn.disconnect.assert_awaited_once()
+    mock_pitboss.stop.assert_awaited_once()
+
+
+async def test_setup_entry_ble_connects_and_forwards_platforms(
+    hass: HomeAssistant, mock_pitboss: Mock
+) -> None:
+    with patch("pytboss.ble.BleConnection", autospec=True) as mock_ble_cls:
+        mock_ble_conn = mock_ble_cls.return_value
+        mock_ble_conn.is_connected.return_value = True
+        mock_pitboss.get_state.return_value = {}
+
+        entry = MockConfigEntry(
+            title="title",
+            domain=DOMAIN,
+            data={
+                CONF_DEVICE_ID: "mygrill",
+                CONF_MODEL: "PBV4PS2",
+                CONF_PASSWORD: "asdfasdf",
+                CONF_PROTOCOL: PROTOCOL_BLE,
+            },
+            unique_id="mygrillid",
+        )
+        entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.LOADED
+    assert DOMAIN in hass.config_entries.async_domains()
+
+
+async def test_connect_ble_timeout_raises_not_ready(
+    hass: HomeAssistant, mock_pitboss: Mock
+) -> None:
+    with (
+        patch("pytboss.ble.BleConnection", autospec=True) as mock_ble_cls,
+        patch(
+            "custom_components.pitboss.timeout",
+            side_effect=lambda _seconds: asyncio.timeout(0),
+        ),
+    ):
+        mock_ble_conn = mock_ble_cls.return_value
+        mock_ble_conn.is_connected.return_value = False
+
+        entry = MockConfigEntry(
+            title="title",
+            domain=DOMAIN,
+            data={
+                CONF_DEVICE_ID: "mygrill",
+                CONF_MODEL: "PBV4PS2",
+                CONF_PASSWORD: "asdfasdf",
+                CONF_PROTOCOL: PROTOCOL_BLE,
+            },
+            unique_id="mygrillid",
+        )
+        entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_unload_entry_stops_api(
+    hass: HomeAssistant, mock_wss_conn: Mock, mock_pitboss: Mock
+) -> None:
+    mock_pitboss.get_state.return_value = {}
+    entry = MockConfigEntry(
+        title="title",
+        domain=DOMAIN,
+        data={
+            CONF_DEVICE_ID: "mygrill",
+            CONF_MODEL: "PBV4PS2",
+            CONF_PASSWORD: "asdfasdf",
+            CONF_PROTOCOL: PROTOCOL_WSS,
+        },
+        unique_id="mygrillid",
+    )
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    assert entry.state is ConfigEntryState.LOADED
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+    assert entry.state is ConfigEntryState.NOT_LOADED
+    assert entry.entry_id not in hass.data.get(DOMAIN, {})
+    mock_pitboss.stop.assert_awaited_once()

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -1,8 +1,16 @@
 from collections.abc import Awaitable, Callable
+from unittest.mock import Mock
 
 import pytest
+from conftest import get_entity
 from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.pitboss.const import DOMAIN
+from custom_components.pitboss.coordinator import PitBossDataUpdateCoordinator
+from custom_components.pitboss.light import GrillLight
+
+ENTITY_ID = "light.mygrill_light"
 
 
 @pytest.mark.parametrize("model,has_light", [("PBV4PS2", False), ("PB2180LK", True)])
@@ -12,8 +20,66 @@ async def test_creates_entity(
     has_light: bool,
 ) -> None:
     await mock_add_config_entry()
-    light = hass.states.get("light.mygrill_light")
+    light = hass.states.get(ENTITY_ID)
     if has_light:
         assert light is not None
     else:
         assert light is None
+
+
+@pytest.mark.parametrize("model", ["PB2180LK"])
+async def test_availability_and_is_on(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+) -> None:
+    entry = await mock_add_config_entry()
+    coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+
+    # No data: unavailable.
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == "unavailable"
+
+    coordinator.async_set_updated_data({"lightState": True})
+    await hass.async_block_till_done()
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == "on"
+
+    coordinator.async_set_updated_data({"lightState": False})
+    await hass.async_block_till_done()
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == "off"
+
+
+@pytest.mark.parametrize("model", ["PB2180LK"])
+async def test_turn_on_and_off(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+    mock_pitboss: Mock,
+) -> None:
+    entry = await mock_add_config_entry()
+    coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator.async_set_updated_data({"lightState": False})
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        "light", "turn_on", {"entity_id": ENTITY_ID}, blocking=True
+    )
+    mock_pitboss.turn_light_on.assert_awaited_once()
+
+    await hass.services.async_call(
+        "light", "turn_off", {"entity_id": ENTITY_ID}, blocking=True
+    )
+    mock_pitboss.turn_light_off.assert_awaited_once()
+
+
+@pytest.mark.parametrize("model", ["PB2180LK"])
+async def test_is_on_none_without_data(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+) -> None:
+    await mock_add_config_entry()
+    entity = get_entity(hass, "light", ENTITY_ID, GrillLight)
+    assert entity.is_on is None

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -1,0 +1,103 @@
+from collections.abc import Awaitable, Callable
+from unittest.mock import Mock
+
+import pytest
+from conftest import get_entity
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.pitboss.const import DOMAIN
+from custom_components.pitboss.coordinator import PitBossDataUpdateCoordinator
+from custom_components.pitboss.number import TargetProbeTemperature
+
+
+@pytest.mark.parametrize("model", ["PBV4PS2"])
+async def test_only_probe_1_entity_created(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+) -> None:
+    await mock_add_config_entry()
+    assert hass.states.get("number.mygrill_probe_1_target") is not None
+    assert hass.states.get("number.mygrill_probe_2_target") is None
+
+
+@pytest.mark.parametrize("model", ["PB1150PS3"])
+async def test_both_probe_entities_created(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+) -> None:
+    await mock_add_config_entry()
+    assert hass.states.get("number.mygrill_probe_1_target") is not None
+    assert hass.states.get("number.mygrill_probe_2_target") is not None
+
+
+@pytest.mark.parametrize("model", ["PB2180LK"])
+async def test_no_probe_entities_created(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+) -> None:
+    await mock_add_config_entry()
+    assert hass.states.get("number.mygrill_probe_1_target") is None
+    assert hass.states.get("number.mygrill_probe_2_target") is None
+
+
+@pytest.mark.parametrize("model", ["PBV4PS2"])
+async def test_native_value_and_availability(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+) -> None:
+    entry = await mock_add_config_entry()
+    coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+
+    # No matching probe temperature reported: entity unavailable.
+    coordinator.async_set_updated_data({"p1Target": 165, "isFahrenheit": True})
+    await hass.async_block_till_done()
+    state = hass.states.get("number.mygrill_probe_1_target")
+    assert state is not None
+    assert state.state == "unavailable"
+
+    coordinator.async_set_updated_data(
+        {"p1Target": 165, "p1Temp": 70, "isFahrenheit": True}
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get("number.mygrill_probe_1_target")
+    assert state is not None
+    assert state.state == "165"
+    assert state.attributes["unit_of_measurement"] == "°F"
+    assert state.attributes["step"] == 1
+    assert state.attributes["min"] == 50
+    assert state.attributes["max"] == 250
+
+
+@pytest.mark.parametrize("model", ["PBV4PS2"])
+async def test_set_native_value(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+    mock_pitboss: Mock,
+) -> None:
+    entry = await mock_add_config_entry()
+    coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator.async_set_updated_data(
+        {"p1Target": 165, "p1Temp": 70, "isFahrenheit": True}
+    )
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        "number",
+        "set_value",
+        {"entity_id": "number.mygrill_probe_1_target", "value": 180},
+        blocking=True,
+    )
+    mock_pitboss.set_probe_temperature.assert_awaited_once_with(180)
+
+
+@pytest.mark.parametrize("model", ["PBV4PS2"])
+async def test_native_value_none_without_data(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+) -> None:
+    await mock_add_config_entry()
+    entity = get_entity(
+        hass, "number", "number.mygrill_probe_1_target", TargetProbeTemperature
+    )
+    assert entity.native_value is None

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,0 +1,113 @@
+from collections.abc import Awaitable, Callable
+from typing import cast
+
+import pytest
+from conftest import get_entity
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from pytboss.grills import StateDict
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.pitboss.const import DOMAIN
+from custom_components.pitboss.coordinator import PitBossDataUpdateCoordinator
+from custom_components.pitboss.sensor import ProbeSensor
+
+
+@pytest.mark.parametrize("model", ["PBV4PS2"])
+async def test_probe_sensors_enabled_by_meat_probes(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+) -> None:
+    # PBV4PS2 has 2 meat probes, so probes 1-2 are enabled by default and
+    # probes 3-4 are registered but disabled.
+    await mock_add_config_entry()
+    registry = er.async_get(hass)
+    assert hass.states.get("sensor.mygrill_probe_1") is not None
+    assert hass.states.get("sensor.mygrill_probe_2") is not None
+    assert hass.states.get("sensor.mygrill_probe_3") is None
+    assert hass.states.get("sensor.mygrill_probe_4") is None
+    entity_id = registry.async_get_entity_id("sensor", DOMAIN, "probe3_mygrillid")
+    assert entity_id is not None
+    entry = registry.async_get(entity_id)
+    assert entry is not None
+    assert entry.disabled_by is not None
+
+
+@pytest.mark.parametrize("model", ["PBV4PS2"])
+async def test_recipe_sensors_created_when_supported(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+) -> None:
+    await mock_add_config_entry()
+    assert hass.states.get("sensor.mygrill_recipe_time") is not None
+    assert hass.states.get("sensor.mygrill_recipe_step") is not None
+
+
+@pytest.mark.parametrize("model", ["PB2180LK"])
+async def test_recipe_sensors_absent_when_unsupported(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+) -> None:
+    await mock_add_config_entry()
+    assert hass.states.get("sensor.mygrill_recipe_time") is None
+    assert hass.states.get("sensor.mygrill_recipe_step") is None
+
+
+@pytest.mark.parametrize("model", ["PBV4PS2"])
+async def test_probe_native_value_and_unit(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+) -> None:
+    # hass units default to US customary (Fahrenheit), so the sensor's
+    # native Celsius value gets auto-converted for display.
+    entry = await mock_add_config_entry()
+    coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator.async_set_updated_data({"p1Temp": 165, "isFahrenheit": True})
+    await hass.async_block_till_done()
+    state = hass.states.get("sensor.mygrill_probe_1")
+    assert state is not None
+    assert state.state == "165"
+    assert state.attributes["unit_of_measurement"] == "°F"
+
+    coordinator.async_set_updated_data({"p1Temp": 74, "isFahrenheit": False})
+    await hass.async_block_till_done()
+    state = hass.states.get("sensor.mygrill_probe_1")
+    assert state is not None
+    assert state.state == "165.2"
+    assert state.attributes["unit_of_measurement"] == "°F"
+
+
+@pytest.mark.parametrize("model", ["PBV4PS2"])
+async def test_recipe_sensor_availability(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+) -> None:
+    entry = await mock_add_config_entry()
+    coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    # recipeStep is really an int at runtime, despite pytboss's StateDict
+    # (incorrectly) typing it as bool.
+    coordinator.async_set_updated_data(
+        cast(StateDict, {"moduleIsOn": False, "recipeStep": 2})
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get("sensor.mygrill_recipe_step")
+    assert state is not None
+    assert state.state == "unavailable"
+
+    coordinator.async_set_updated_data(
+        cast(StateDict, {"moduleIsOn": True, "recipeStep": 2})
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get("sensor.mygrill_recipe_step")
+    assert state is not None
+    assert state.state == "2"
+
+
+@pytest.mark.parametrize("model", ["PBV4PS2"])
+async def test_native_value_none_without_data(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+) -> None:
+    await mock_add_config_entry()
+    entity = get_entity(hass, "sensor", "sensor.mygrill_probe_1", ProbeSensor)
+    assert entity.native_value is None

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1,0 +1,135 @@
+from collections.abc import Awaitable, Callable
+from unittest.mock import Mock
+
+import pytest
+from conftest import get_entity
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.pitboss.const import DOMAIN
+from custom_components.pitboss.coordinator import PitBossDataUpdateCoordinator
+from custom_components.pitboss.switch import PowerSwitch
+
+
+@pytest.mark.parametrize("model", ["PBV4PS2"])
+async def test_both_switches_created(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+) -> None:
+    await mock_add_config_entry()
+    assert hass.states.get("switch.mygrill_module_power") is not None
+    assert hass.states.get("switch.mygrill_prime") is not None
+
+
+@pytest.mark.parametrize("model", ["PB1020CS2"])
+async def test_primer_switch_absent_when_unsupported(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+) -> None:
+    await mock_add_config_entry()
+    assert hass.states.get("switch.mygrill_module_power") is not None
+    assert hass.states.get("switch.mygrill_prime") is None
+
+
+@pytest.mark.parametrize("model", ["PBV4PS2"])
+async def test_is_on_and_availability(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+) -> None:
+    entry = await mock_add_config_entry()
+    coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+
+    coordinator.async_set_updated_data({"moduleIsOn": True, "primeState": False})
+    await hass.async_block_till_done()
+    power_state = hass.states.get("switch.mygrill_module_power")
+    prime_state = hass.states.get("switch.mygrill_prime")
+    assert power_state is not None
+    assert prime_state is not None
+    assert power_state.state == "on"
+    assert prime_state.state == "off"
+
+    coordinator.async_set_updated_data({"moduleIsOn": False, "primeState": False})
+    await hass.async_block_till_done()
+    # All switches are unavailable when the module (grill) is off, since
+    # availability is gated on the shared "moduleIsOn" key.
+    power_state = hass.states.get("switch.mygrill_module_power")
+    prime_state = hass.states.get("switch.mygrill_prime")
+    assert power_state is not None
+    assert prime_state is not None
+    assert prime_state.state == "unavailable"
+    assert power_state.state == "unavailable"
+
+
+@pytest.mark.parametrize("model", ["PBV4PS2"])
+async def test_power_switch_turn_on_is_a_noop(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+    mock_pitboss: Mock,
+) -> None:
+    entry = await mock_add_config_entry()
+    coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator.async_set_updated_data({"moduleIsOn": False})
+    await hass.async_block_till_done()
+
+    entity = get_entity(hass, "switch", "switch.mygrill_module_power", PowerSwitch)
+    await entity.async_turn_on()
+    mock_pitboss.turn_grill_off.assert_not_awaited()
+
+
+@pytest.mark.parametrize("model", ["PBV4PS2"])
+async def test_power_switch_turn_off(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+    mock_pitboss: Mock,
+) -> None:
+    entry = await mock_add_config_entry()
+    coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator.async_set_updated_data({"moduleIsOn": True})
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        "switch",
+        "turn_off",
+        {"entity_id": "switch.mygrill_module_power"},
+        blocking=True,
+    )
+    mock_pitboss.turn_grill_off.assert_awaited_once()
+    mock_pitboss.set_grill_temperature.assert_awaited_once_with(temp=130)
+
+
+@pytest.mark.parametrize("model", ["PBV4PS2"])
+async def test_primer_switch_turn_on_off(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+    mock_pitboss: Mock,
+) -> None:
+    entry = await mock_add_config_entry()
+    coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator.async_set_updated_data({"moduleIsOn": True, "primeState": False})
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        "switch",
+        "turn_on",
+        {"entity_id": "switch.mygrill_prime"},
+        blocking=True,
+    )
+    mock_pitboss.turn_primer_motor_on.assert_awaited_once()
+
+    await hass.services.async_call(
+        "switch",
+        "turn_off",
+        {"entity_id": "switch.mygrill_prime"},
+        blocking=True,
+    )
+    mock_pitboss.turn_primer_motor_off.assert_awaited_once()
+
+
+@pytest.mark.parametrize("model", ["PBV4PS2"])
+async def test_is_on_none_without_data(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+) -> None:
+    await mock_add_config_entry()
+    entity = get_entity(hass, "switch", "switch.mygrill_module_power", PowerSwitch)
+    assert entity.is_on is None


### PR DESCRIPTION
## Summary
- Adds tests for previously untested modules: `binary_sensor`, `sensor`, `number`, `switch`, `coordinator`, `config_flow`, and `__init__` (config entry setup/unload, including the BLE and WSS connection paths).
- Expands `climate` and `light` tests to cover service calls (`set_temperature`, `set_hvac_mode`, `turn_on`/`turn_off`), HVAC mode/action branches, and availability edge cases.
- Overall coverage goes from ~9% to 99% (523 statements, 7 uncovered — a BLE device-detection retry callback that needs unreliable real-hardware async timing to exercise deterministically).
- Fixes two bugs surfaced while writing tests:
  - `GrillLight` never set `color_mode`, so turning the light on in a real Home Assistant instance would raise `HomeAssistantError: does not report a color mode`.
  - `LOGGER.warn` is deprecated; switched to `LOGGER.warning` in `climate.py` and `switch.py`.

## Test plan
- [x] `uv run pytest --cov=custom_components.pitboss --cov-report=term-missing` — 68 passed, 99% coverage
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run mypy .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)