### PR TITLE
Drop the PBL2 control board workaround

### DIFF
--- a/custom_components/pitboss/config_flow.py
+++ b/custom_components/pitboss/config_flow.py
@@ -86,8 +86,6 @@ class PitBossFlowHandler(ConfigFlow, domain=DOMAIN):
     ) -> ConfigFlowResult:
         """Show the more_info form."""
         control_board = self._device_id.split("-")[0]
-        if control_board == "PBL2":
-            control_board = "PBL3"
         models = [g.name for g in grills.get_grills(control_board=control_board)]
         if not models:
             return self.async_abort(

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -7,6 +7,7 @@ from homeassistant.components.bluetooth import BluetoothServiceInfoBleak
 from homeassistant.const import CONF_DEVICE_ID, CONF_MODEL, CONF_PASSWORD, CONF_PROTOCOL
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from pytboss import grills
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.pitboss.const import DOMAIN, PROTOCOL_WSS
@@ -84,21 +85,47 @@ async def test_user_flow_creates_entry(hass: HomeAssistant) -> None:
     }
 
 
-async def test_user_flow_pbl2_maps_to_pbl3_control_board(
-    hass: HomeAssistant,
+@pytest.mark.parametrize("control_board", ["PBL2", "LBL", "LFS"])
+async def test_user_flow_offers_that_control_boards_models(
+    hass: HomeAssistant, control_board: str
 ) -> None:
+    """The flow lists the models for the board the grill advertises.
+
+    PBL2 used to be rewritten to PBL3 because pytboss had no PBL2 definitions,
+    and LBL and LFS aborted the flow outright for the same reason, so a grill
+    could be discovered but not added.
+    """
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_DEVICE_ID: f"{control_board}-ABC123"}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "more_info"
+    data_schema = result["data_schema"]
+    assert data_schema is not None
+    models = set(data_schema.schema[CONF_MODEL].container)
+    assert models == {g.name for g in grills.get_grills(control_board)}
+    assert models
+
+
+async def test_user_flow_pbl2_is_not_rewritten_to_pbl3(hass: HomeAssistant) -> None:
+    """A PBL2 grill gets PBL2 definitions, not the ones PBL3 ships.
+
+    The two boards parse temperatures differently, so resolving one as the
+    other is not harmless.
+    """
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {CONF_DEVICE_ID: "PBL2-ABC123"}
     )
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "more_info"
     data_schema = result["data_schema"]
     assert data_schema is not None
-    models = data_schema.schema[CONF_MODEL].container
-    assert len(models) > 0
+    models = set(data_schema.schema[CONF_MODEL].container)
+    assert models != {g.name for g in grills.get_grills("PBL3")}
 
 
 async def test_user_flow_already_configured_aborts(hass: HomeAssistant) -> None:


### PR DESCRIPTION
## Summary

Removes the `PBL2` special case from the config flow:

```diff
 control_board = self._device_id.split("-")[0]
-if control_board == "PBL2":
-    control_board = "PBL3"
 models = [g.name for g in grills.get_grills(control_board=control_board)]
```

That rewrite existed because `grills.json` had no `PBL2` entry at all. The vendor serves `PB850DX` and `PB1150DX` on both board generations, and the dump kept only the higher grill ID, discarding `PBL2`. [dknowles2/pytboss#497](https://github.com/dknowles2/pytboss/pull/497) keeps both, so the board resolves on its own:

```
get_grills('PBL2'): ['PB1150DX', 'PB850DX']
get_grills('PBL3'): ['PB1020DX', 'PB1150DX', 'PB850DX', 'PBV4DX']
```

Rebased on `main`, which now carries pytboss 2026.8.1 via #316 — the version these tests need. Before 2026.8.0 there were no `PBL2` definitions to resolve and `LBL`/`LFS` were unsupported entirely.

## Test change

`test_user_flow_pbl2_maps_to_pbl3_control_board` described behaviour that no longer exists, and only asserted that *some* models came back — so it would have passed either way while continuing to document the wrong thing.

Replaced with a parametrized check that each of `PBL2`, `LBL` and `LFS` is offered its own board's models, plus one asserting `PBL2` is not served `PBL3`'s list. That second one is the regression worth catching, since the two boards parse temperatures differently.

The `LBL`/`LFS` cases also cover what the 2026.8.1 bump enables: those grills are already discovered by the manifest but used to abort the flow with `unknown_grill`, so they could be found but not added. This supersedes #258, which worked around that by aliasing `LBL` to `PBL` — an alias that would have read LBL frames at PBL offsets, three bytes apart.

## What this does not fix

A `PBL2` grill still parses temperatures as a `PBL3`. `PBL3` applies a fahrenheit-to-celsius conversion that `PBL2` has commented out, so a `PBL2` grill **set to celsius is converted twice** — 225 shown as 107. In fahrenheit the block is skipped, which is presumably why it has gone unreported.

Fixing it means passing the advertised board to `PitBoss`, using the `control_board` argument added in [pytboss#503](https://github.com/dknowles2/pytboss/pull/503) and shipped in 2026.8.1. That is a separate change, and needs care for the manual-entry case where a device ID has no board prefix at all.

## Verified

`ruff check` and `mypy .` clean.

I cannot run the tests locally — `homeassistant.setup` fails to start the `bluetooth` component in my environment, and every test in the file fails that way including ones this PR does not touch — so the new tests are unverified by me and CI is the check.

I did confirm the assertions are not vacuous, by resolving each board against the installed pytboss 2026.8.1 directly:

```
PBL2: ['PB1150DX', 'PB850DX']
PBL3: ['PB1020DX', 'PB1150DX', 'PB850DX', 'PBV4DX']
LBL:  ['LG0800BL', 'LG1000BL', 'LG1200BL', 'LG300BL', 'LGV4BL']
LFS:  ['LG1200FL', 'LG1200FP', 'LG800FL', 'LG800FP']
```

Each is non-empty and distinct, so both the equality assertion and the `PBL2 != PBL3` one have something to bite on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
