### PR TITLE
Update pytboss to 2026.8.1

### DIFF
--- a/custom_components/pitboss/manifest.json
+++ b/custom_components/pitboss/manifest.json
@@ -77,7 +77,7 @@
     "pytboss"
   ],
   "requirements": [
-    "pytboss==2026.7.0"
+    "pytboss==2026.8.1"
   ],
   "version": "0000.0.0"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ mypy==2.3.0
 pip>=26.2
 pyserial-asyncio==0.6
 pyserial==3.5
-pytboss==2026.7.0
+pytboss==2026.8.1
 pytest_homeassistant_custom_component==0.13.348
 ruff==0.16.0
 serialx==1.8.2


### PR DESCRIPTION
## Summary

Bumps `pytboss` from 2026.7.0 to 2026.8.1 in `requirements.txt` and `manifest.json`. Two files, nothing else — `docs/SUPPORTED_GRILLS.md` is left to `update-grill-docs.yml`, which regenerates it on push to `main` whenever the pinned version changes.

## What it brings in

**Louisiana Grills support** ([dknowles2/pytboss#491](https://github.com/dknowles2/pytboss/pull/491)) — the LBL and LFS parsing routines are fixed, so those nine models leave pytboss's unsupported list. The manifest already discovers `LBL-*` and `LFS-*`, but the flow aborted with `unknown_grill`, so a grill could be found and not added. #315 covers the config flow side.

**`PitBoss(..., control_board=...)`** ([pytboss#503](https://github.com/dknowles2/pytboss/pull/503)). Not used yet. A follow-up will pass the board a grill advertises so a `PB850DX` or `PB1150DX` resolves to the generation it ships with rather than always the newer one — PBL3 applies a fahrenheit-to-celsius conversion that PBL2 does not, so a PBL2 grill set to celsius is currently converted twice.

**A much smaller `grills.json`** — 1.19 MB to 262 KB ([#500](https://github.com/dknowles2/pytboss/pull/500), [#501](https://github.com/dknowles2/pytboss/pull/501)). Checked that nothing this integration reads went with it:

```
min_temp/max_temp: 130 420
meat_probes: 2 | has_lights: False
has_recipe_functionality (sensor.py): 1
image_url (docs/readme): True
commands: 11
missing after the trim: none
```

`has_recipe_functionality` is the one worth naming: `sensor.py` reaches for it through the untyped `Grill.json`, so its disappearance would not have failed type checking. It is retained.

## Heads up: the docs workflow may not be able to push

`update-grill-docs.yml` is set up to regenerate the doc on push to `main`, but **that push has never actually happened**. Its only run to date, for the 2026.7.0 bump, regenerated the file, found it already current, and took the early exit:

```
Wrote /home/runner/work/ha-pitboss/ha-pitboss/docs/SUPPORTED_GRILLS.md (128 grills)
No changes to docs/SUPPORTED_GRILLS.md
```

This time there will be changes — nine models — so `git push` gets attempted for the first time. The `Main` ruleset requires a pull request on the default branch and its only bypass is `RepositoryRole:5` (admin), which `github-actions[bot]` is not, so the push looks likely to be rejected.

Worth watching the run after this merges. If it fails, the fix is the same shape as [pytboss#498](https://github.com/dknowles2/pytboss/pull/498): open a pull request instead of pushing, using a token whose PRs trigger workflows so the required checks can report.

## Ordering

[#315](https://github.com/dknowles2/ha-pitboss/pull/315) removes the `PBL2 -> PBL3` workaround from the config flow, which needs 2026.8.0 or newer. **Merge this first**; I will rebase #315 onto it.

## Verified

`ruff check` and `mypy .` clean. I cannot run the test suite locally — `homeassistant.setup` fails to start the `bluetooth` component in my environment, on unmodified `main` too — so CI is the check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
