### PR TITLE
Allow the grill docs workflow to be run on demand

### DIFF
--- a/.github/workflows/update-grill-docs.yml
+++ b/.github/workflows/update-grill-docs.yml
@@ -19,6 +19,11 @@ on:
     branches: [main]
     paths:
       - requirements.txt
+  # Lets the docs be brought up to date without waiting for a version bump,
+  # and gives the push a way to be exercised: it only ever ran once before,
+  # found nothing to commit, and so never revealed that the Main ruleset
+  # rejects it.
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -34,7 +39,12 @@ jobs:
       - name: 🔍 Check whether pytboss version changed
         id: check
         run: |
-          if git diff HEAD^ HEAD -- requirements.txt | grep -q '^[+-]pytboss=='; then
+          # A manual run has no version bump to diff against, and is only ever
+          # started because someone wants the docs regenerated, so take it at
+          # its word.
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          elif git diff HEAD^ HEAD -- requirements.txt | grep -q '^[+-]pytboss=='; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "changed=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Part of #318.

## Summary

`update-grill-docs.yml` only triggered on a push to `main` that changed the pinned `pytboss` version. That left no way to bring the docs up to date after a bump had already landed — the situation right now, since #316 merged and the automatic run was rejected — and no way to exercise the commit-and-push step at all.

That second part is why the ruleset problem went unnoticed for so long: the push had never once run, so nothing revealed that `main`'s ruleset rejects it, and the workflow reported success throughout.

```yaml
  workflow_dispatch:
```

## The gate needed adjusting too

Adding the trigger alone would have made a manual run a silent no-op. The first step decides whether to continue by diffing the previous commit:

```bash
git diff HEAD^ HEAD -- requirements.txt | grep -q '^[+-]pytboss=='
```

A manual run has no version bump to diff against, so `changed=false` and every remaining step is skipped. It now treats `workflow_dispatch` as reason enough on its own, since a manual run only ever happens because someone wants the docs regenerated:

```bash
if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
  echo "changed=true" >> "$GITHUB_OUTPUT"
elif git diff HEAD^ HEAD -- requirements.txt | grep -q '^[+-]pytboss=='; then
  ...
```

Verified both paths: `workflow_dispatch` with no pytboss diff yields `changed=true`, a `push` with no pytboss diff still yields `changed=false`.

## Note

This does not fix the push itself — that needs the ruleset bypass discussed in #318. It makes the fix testable: once the bypass is in place, dispatching this workflow confirms it works and catches the docs up, rather than waiting for the next version bump to find out.

If the bypass is not added, a dispatch will fail the same way the automatic run did, which is at least a fast and explicit way to check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
