### PR TITLE
Push the grill docs with a deploy key

### DIFF
--- a/.github/workflows/update-grill-docs.yml
+++ b/.github/workflows/update-grill-docs.yml
@@ -25,16 +25,30 @@ on:
   # rejects it.
   workflow_dispatch:
 
+# The push below is made with a deploy key, not GITHUB_TOKEN, so the token
+# itself needs no write access.
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   update-grill-docs:
     runs-on: ubuntu-latest
+    # Pushing to main means bypassing the Main ruleset. That bypass is granted
+    # to one write-enabled deploy key rather than to the Actions app, so no
+    # other workflow's GITHUB_TOKEN can reach main. The key's private half is
+    # an environment secret and this environment is restricted to main, so a
+    # workflow on any other branch cannot read it either.
+    environment: docs
     steps:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 2 # Need the previous commit to diff requirements.txt.
+          # Clones over SSH with the deploy key, so the push at the end is
+          # authenticated as the key. Unlike GITHUB_TOKEN, a deploy key push
+          # does trigger workflows -- harmless here, because the commit only
+          # touches docs/ and the push trigger above filters on
+          # requirements.txt, so this cannot re-fire itself.
+          ssh-key: ${{ secrets.DOCS_DEPLOY_KEY }}
 
       - name: 🔍 Check whether pytboss version changed
         id: check


### PR DESCRIPTION
The first dispatched run of `update-grill-docs.yml` failed with
`GH013: Repository rule violations found for refs/heads/main` — the `Main`
ruleset has no bypass for the Actions app, so `GITHUB_TOKEN` cannot push.

The obvious fix is to add `Integration:15368` (the GitHub Actions app) as a
bypass actor, but that actor is behind *every* workflow's `GITHUB_TOKEN`, not
just this one. Repo default workflow permissions are `write`, and three of the
seven workflows rely on that default, so the grant would be considerably wider
than the one job that needs it.

This uses a write-enabled deploy key instead:

* the bypass actor is the key, so `GITHUB_TOKEN` still cannot reach `main` from
  any workflow;
* the private half is an **environment** secret, not a repo secret, so only a
  job declaring `environment: docs` can read it, and that environment is
  restricted to `main`;
* `permissions` drops from `contents: write` to `contents: read`, since the
  token no longer does the pushing.

### Requires setup before merging

The `docs` environment, the deploy key, the secret, and the ruleset bypass all
have to exist first — a job referencing a missing environment causes GitHub to
create an unprotected one implicitly, which would quietly discard the branch
restriction that makes this safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)