### PR TITLE
Fix misspelled local variable in binary_sensor setup

### DIFF
--- a/custom_components/pitboss/binary_sensor.py
+++ b/custom_components/pitboss/binary_sensor.py
@@ -100,11 +100,11 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ):
     """Setup binary_sensor platform."""
-    coordiantor: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
     entities: list[BinarySensor] = []
     assert entry.unique_id is not None
     for entity_description in ENTITY_DESCRIPTIONS:
-        entities.append(BinarySensor(coordiantor, entry.unique_id, entity_description))
+        entities.append(BinarySensor(coordinator, entry.unique_id, entity_description))
     async_add_entities(entities)
 
 


### PR DESCRIPTION
First of the three in set 1 from #321.

`coordiantor` is a typo for `coordinator`. Local variable only, no behaviour change, no test needed.