### PR TITLE
Mark the light unavailable when the grill is disconnected

### DIFF
--- a/custom_components/pitboss/light.py
+++ b/custom_components/pitboss/light.py
@@ -40,7 +40,10 @@ class GrillLight(BaseEntity, LightEntity):
 
     @property
     def available(self) -> bool:
-        return bool(self.coordinator.data)
+        # Deferring to BaseEntity also checks the connection. Without that,
+        # the light kept reporting its last known state after the grill went
+        # away, unlike every other platform.
+        return super().available
 
     @property
     def is_on(self) -> bool | None:

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -96,9 +96,13 @@ async def test_unavailable_when_disconnected(
     coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
     coordinator.async_set_updated_data({"lightState": True})
     await hass.async_block_till_done()
-    assert hass.states.get(ENTITY_ID).state == "on"
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == "on"
 
     mock_pitboss.is_connected.return_value = False
     coordinator.async_set_updated_data({"lightState": True})
     await hass.async_block_till_done()
-    assert hass.states.get(ENTITY_ID).state == "unavailable"
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == "unavailable"

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -83,3 +83,22 @@ async def test_is_on_none_without_data(
     await mock_add_config_entry()
     entity = get_entity(hass, "light", ENTITY_ID, GrillLight)
     assert entity.is_on is None
+
+
+@pytest.mark.parametrize("model", ["PB2180LK"])
+async def test_unavailable_when_disconnected(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+    mock_pitboss: Mock,
+) -> None:
+    """State is not reported once the grill is gone, even if data was cached."""
+    entry = await mock_add_config_entry()
+    coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator.async_set_updated_data({"lightState": True})
+    await hass.async_block_till_done()
+    assert hass.states.get(ENTITY_ID).state == "on"
+
+    mock_pitboss.is_connected.return_value = False
+    coordinator.async_set_updated_data({"lightState": True})
+    await hass.async_block_till_done()
+    assert hass.states.get(ENTITY_ID).state == "unavailable"


### PR DESCRIPTION
Set 1 of #321.

`GrillLight.available` only checked that the coordinator had data:

```python
return bool(self.coordinator.data)
```

So once the grill went away, the light kept reporting whichever state was cached, while every other platform correctly went unavailable — `BaseEntity.available` requires a live connection as well.

Deferring to `super().available` restores the connection check. The existing "no data → unavailable" case is unaffected, since the base property also requires data.

Added a test that fails on `main`: data present, connection gone, entity must be unavailable.