### PR TITLE
Release the transport when setup fails for any reason

### DIFF
--- a/custom_components/pitboss/__init__.py
+++ b/custom_components/pitboss/__init__.py
@@ -116,7 +116,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
     try:
         await coordinator.async_config_entry_first_refresh()
-    except ConfigEntryNotReady:
+    except Exception:
+        # Any failure here aborts the setup, so the transport has to be
+        # released. Catching only ConfigEntryNotReady stranded the socket and
+        # its receive task on every other error, and each retry added another.
+        hass.data[DOMAIN].pop(entry.entry_id, None)
         await conn.disconnect()
         await pitboss.stop()
         raise

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -9,6 +9,7 @@ from pytboss.exceptions import GrillUnavailable
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.pitboss.const import DOMAIN, PROTOCOL_BLE, PROTOCOL_WSS
+from custom_components.pitboss.coordinator import PitBossDataUpdateCoordinator
 
 pytestmark = pytest.mark.parametrize("model", ["PBV4PS2"])
 
@@ -140,3 +141,33 @@ async def test_unload_entry_stops_api(
     assert entry.state is ConfigEntryState.NOT_LOADED
     assert entry.entry_id not in hass.data.get(DOMAIN, {})
     mock_pitboss.stop.assert_awaited_once()
+
+
+async def test_setup_entry_releases_transport_on_unexpected_error(
+    hass: HomeAssistant, mock_wss_conn: Mock, mock_pitboss: Mock
+) -> None:
+    """Any first-refresh failure releases the transport, not just not-ready."""
+    entry = MockConfigEntry(
+        title="title",
+        domain=DOMAIN,
+        data={
+            CONF_DEVICE_ID: "mygrill",
+            CONF_MODEL: "PBV4PS2",
+            CONF_PASSWORD: "asdfasdf",
+            CONF_PROTOCOL: PROTOCOL_WSS,
+        },
+        unique_id="mygrillid",
+    )
+    entry.add_to_hass(hass)
+    with patch.object(
+        PitBossDataUpdateCoordinator,
+        "async_config_entry_first_refresh",
+        side_effect=RuntimeError("boom"),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.SETUP_ERROR
+    mock_wss_conn.disconnect.assert_awaited_once()
+    mock_pitboss.stop.assert_awaited_once()
+    assert entry.entry_id not in hass.data.get(DOMAIN, {})


### PR DESCRIPTION
Set 1 of #321.

The first-refresh failure path only caught `ConfigEntryNotReady`:

```python
try:
    await coordinator.async_config_entry_first_refresh()
except ConfigEntryNotReady:
    await conn.disconnect()
    await pitboss.stop()
    raise
```

Any other exception propagates without the cleanup, leaving the connection open together with its receive task. Since HA retries setup, each attempt strands another one.

This catches everything, drops the coordinator from `hass.data` (it is inserted before the refresh), disconnects, stops the API, and re-raises unchanged so HA still classifies the failure itself.

Added a test that fails on `main`: an unexpected error during the first refresh must still disconnect, stop, and leave nothing behind in `hass.data`.

I hit this via a reauth change further down the roadmap, but the leak is reachable on `main` today for any unexpected error.