### PR TITLE
Keep fields missing from a partial state frame

### DIFF
--- a/custom_components/pitboss/coordinator.py
+++ b/custom_components/pitboss/coordinator.py
@@ -37,9 +37,32 @@ class PitBossDataUpdateCoordinator(DataUpdateCoordinator[StateDict]):
         await self.api.subscribe_state(self._on_state_update)
         await self._start_api()
 
+    def _merge_state(self, state: StateDict) -> StateDict:
+        """Fold a state frame onto the last known one.
+
+        The board answers with two independent frames, status (`sc_11`) and
+        temperatures (`sc_12`), and clears them as soon as it forwards a
+        command to the MCU. A read landing in that window returns one frame
+        without the other, and pytboss simply omits the missing half's keys,
+        so every entity backed by them would go unknown until the next
+        successful read.
+
+        Only *absent* keys are carried over. A key present with a null value
+        is a real reading -- an unplugged probe -- and overwrites.
+        """
+        # Copy rather than hand back the incoming dict: pytboss gives every
+        # subscriber the same StateDict instance and keeps mutating it.
+        if not self.data:
+            return state.copy()
+        if not state:
+            return self.data
+        merged = self.data.copy()
+        merged.update(state)
+        return merged
+
     async def _on_state_update(self, data: StateDict) -> None:
         self.logger.debug("Received data: %s", data)
-        self.async_set_updated_data(data)
+        self.async_set_updated_data(self._merge_state(data))
 
     async def _start_api(self) -> None:
         try:
@@ -65,7 +88,7 @@ class PitBossDataUpdateCoordinator(DataUpdateCoordinator[StateDict]):
         # Relying solely on push notifications means sensors can go stale after
         # a reconnect if push notifications stop being delivered.
         try:
-            return await self.api.get_state()
+            return self._merge_state(await self.api.get_state())
         except NotConnectedError as ex:
             raise UpdateFailed("Grill not connected") from ex
         except RPCError as ex:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -5,6 +5,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import UpdateFailed
 from pytboss.exceptions import GrillUnavailable, NotConnectedError, RPCError
+from pytboss.grills import StateDict
 
 from custom_components.pitboss.coordinator import PitBossDataUpdateCoordinator
 
@@ -105,3 +106,47 @@ async def test_async_update_data_success(
     data = await coordinator._async_update_data()
     mock_pitboss.ping.assert_awaited_once_with(timeout=10.0)
     assert data == {"grillTemp": 225}
+
+
+async def test_async_update_data_keeps_fields_missing_from_a_partial_frame(
+    coordinator: PitBossDataUpdateCoordinator, mock_pitboss: Mock
+) -> None:
+    """A read between the two frames must not blank the other half."""
+    coordinator._api_started = True
+    mock_pitboss.is_connected.return_value = True
+
+    mock_pitboss.get_state.return_value = {"grillTemp": 225, "moduleIsOn": True}
+    coordinator.async_set_updated_data(await coordinator._async_update_data())
+
+    # Only the status frame came back this time.
+    mock_pitboss.get_state.return_value = {"moduleIsOn": False}
+    data = await coordinator._async_update_data()
+    assert data == {"grillTemp": 225, "moduleIsOn": False}
+
+
+async def test_async_update_data_lets_null_readings_through(
+    coordinator: PitBossDataUpdateCoordinator, mock_pitboss: Mock
+) -> None:
+    """A key present with no value is a real reading, not a missing frame."""
+    coordinator._api_started = True
+    mock_pitboss.is_connected.return_value = True
+
+    mock_pitboss.get_state.return_value = {"p1Temp": 70}
+    coordinator.async_set_updated_data(await coordinator._async_update_data())
+
+    # The probe was unplugged: pytboss reports the key as None.
+    mock_pitboss.get_state.return_value = {"p1Temp": None}
+    data = await coordinator._async_update_data()
+    assert data == {"p1Temp": None}
+
+
+async def test_on_state_update_merges_onto_previous_data(
+    coordinator: PitBossDataUpdateCoordinator,
+) -> None:
+    """Pushed updates are merged too, and never stored by reference."""
+    pushed: StateDict = {"grillTemp": 225, "moduleIsOn": True}
+    await coordinator._on_state_update(pushed)
+    assert coordinator.data is not pushed
+
+    await coordinator._on_state_update({"moduleIsOn": False})
+    assert coordinator.data == {"grillTemp": 225, "moduleIsOn": False}


### PR DESCRIPTION
Set 2 of #321, first of three stacked on each other. Set 1 (#323, #324, #325) is merged — thanks for the quick turnaround.

The board answers with two independent frames, status (`sc_11`) and temperatures (`sc_12`), and clears both the moment it forwards a command to the MCU. A read landing in that window comes back with one frame but not the other, and pytboss omits the missing half's keys entirely — so every entity backed by them goes unknown until the next successful read.

On BLE the push path refills quickly enough that it is easy to miss. On a polling connection it lasts a full interval, and it happens after *every* command, including ones the integration issues itself.

Merging each frame onto the last known state fixes it. Only absent keys are carried over: a key present with a null value is a real reading — an unplugged probe — and still overwrites.

The merge also copies rather than storing the incoming dict, since pytboss hands every subscriber the same `StateDict` instance and keeps mutating it in place.

Three tests: the partial frame case, the null-reading case (a guard that we don't over-merge), and the pushed-update path.