### PR TITLE
Take the climate bounds from the board's setpoint list

### DIFF
--- a/custom_components/pitboss/climate.py
+++ b/custom_components/pitboss/climate.py
@@ -52,6 +52,21 @@ class GrillClimate(BaseEntity, ClimateEntity):
         self._attr_unique_id = f"{self.entity_description.key}_{entry_unique_id}"
 
     @property
+    def _accepted_setpoints(self) -> list[float]:
+        return self.coordinator.accepted_setpoints(self.temperature_unit)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, list[float]] | None:
+        """Publish the setpoints the board accepts.
+
+        The board silently ignores anything else, so a dashboard offering a
+        free slider is misleading. This lets one offer only what works.
+        """
+        if accepted := self._accepted_setpoints:
+            return {"allowed_setpoints": accepted}
+        return None
+
+    @property
     def target_temperature_step(self) -> float:
         if self.temperature_unit == UnitOfTemperature.FAHRENHEIT:
             return 5.0
@@ -60,6 +75,8 @@ class GrillClimate(BaseEntity, ClimateEntity):
 
     @property
     def min_temp(self) -> float:
+        if accepted := self._accepted_setpoints:
+            return min(accepted)
         from_unit = UnitOfTemperature.FAHRENHEIT
         to_unit = self.temperature_unit
         if (min_temp := self.coordinator.api.spec.min_temp) is None:
@@ -68,6 +85,8 @@ class GrillClimate(BaseEntity, ClimateEntity):
 
     @property
     def max_temp(self) -> float:
+        if accepted := self._accepted_setpoints:
+            return max(accepted)
         from_unit = UnitOfTemperature.FAHRENHEIT
         to_unit = self.temperature_unit
         if (max_temp := self.coordinator.api.spec.max_temp) is None:

--- a/custom_components/pitboss/coordinator.py
+++ b/custom_components/pitboss/coordinator.py
@@ -1,6 +1,9 @@
 """DataUpdateCoordinator for PitBoss."""
 
+from math import floor
+
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
@@ -31,6 +34,23 @@ class PitBossDataUpdateCoordinator(DataUpdateCoordinator[StateDict]):
         self.device_info = device_info
         self.api = api
         self._api_started = False
+
+    def accepted_setpoints(self, unit: str) -> list[float]:
+        """Grill setpoints the control board honours, expressed in `unit`.
+
+        The board ignores anything that is not on this list. A couple of
+        models publish a Celsius list of their own; for everyone else it is
+        derived from the Fahrenheit one using the same conversion the boards
+        that convert in their own parsing routine use -- `floor((F - 32) /
+        1.8)` -- so the values match what the panel will show.
+        """
+        fahrenheit = self.api.spec.temp_increments or []
+        if unit != UnitOfTemperature.CELSIUS:
+            return [float(v) for v in fahrenheit]
+        raw = self.api.spec.json.get("celsius_temp_increment") or ""
+        if celsius := [int(v) for v in raw.split("/") if v.strip().isdigit()]:
+            return [float(v) for v in celsius]
+        return [float(floor((v - 32) / 1.8)) for v in fahrenheit]
 
     async def _async_setup(self) -> None:
         """Set up the coordinator."""

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -1,4 +1,5 @@
 from collections.abc import Awaitable, Callable
+from math import floor
 from unittest.mock import Mock
 
 import pytest
@@ -15,7 +16,10 @@ from custom_components.pitboss.coordinator import PitBossDataUpdateCoordinator
 ENTITY_ID = "climate.mygrill_grill_temperature"
 
 
-@pytest.mark.parametrize("model,want", [("PBV4PS2", 130), ("PB2180LK", 180)])
+# PB2180LK publishes no min_temp, so this used to fall back to the
+# DEFAULT_MIN_TEMP constant. Its setpoint list starts at 160, which is the
+# board's real floor, so that is what the entity reports now.
+@pytest.mark.parametrize("model,want", [("PBV4PS2", 130), ("PB2180LK", 160)])
 async def test_min_temp(
     hass: HomeAssistant,
     mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
@@ -221,3 +225,42 @@ async def test_hvac_mode_and_action_none_without_data(
     entity = get_entity(hass, "climate", ENTITY_ID, GrillClimate)
     assert entity.hvac_mode is None
     assert entity.hvac_action is None
+
+
+@pytest.mark.parametrize("model", ["PBV4PS2"])
+async def test_bounds_come_from_the_boards_setpoints(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+) -> None:
+    """Fahrenheit bounds are the first and last accepted setpoints."""
+    entry = await mock_add_config_entry()
+    coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator.async_set_updated_data({"isFahrenheit": True})
+    await hass.async_block_till_done()
+
+    increments = coordinator.api.spec.temp_increments
+    assert increments
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.attributes["min_temp"] == min(increments)
+    assert state.attributes["max_temp"] == max(increments)
+    assert state.attributes["allowed_setpoints"] == [float(v) for v in increments]
+
+
+@pytest.mark.parametrize("model", ["PBV4PS2"])
+async def test_celsius_setpoints_use_the_boards_own_conversion(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+) -> None:
+    """floor((F - 32) / 1.8), matching the boards that convert in their JS."""
+    entry = await mock_add_config_entry()
+    coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator.async_set_updated_data({"isFahrenheit": False})
+    await hass.async_block_till_done()
+
+    increments = coordinator.api.spec.temp_increments
+    assert increments
+    expected = [float(floor((v - 32) / 1.8)) for v in increments]
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.attributes["allowed_setpoints"] == expected


### PR DESCRIPTION
Set 2 of #321. Independent of #326 despite what I said there about stacking — GitHub won't let a PR from a fork use another fork branch as its base, so all three are against `main`. They touch different code and can merge in any order.

`min_temp` and `max_temp` came from `spec.min_temp`/`max_temp`, falling back to module constants when a model publishes neither. The board also publishes the exact list of setpoints it honours, which is a better source — `PB2180LK` has no `min_temp`, so the entity advertised a floor of 180 that the board does not impose, while its own list starts at **160**. That is the one existing expectation this changes, and I updated `test_min_temp` rather than working around it.

Celsius values are derived with `floor((F - 32) / 1.8)` rather than a rounding conversion, because that is what the boards which convert inside their own parsing routine do. Rounding produces values the panel never lands on: to the grill, 190 °F is 87 °C, not 88. Confirmed on my own grill by sending each value and reading back what it stored.

Where a model declares `celsius_temp_increment` that list wins — only PBV30DS/PBV30DX do today, and both are in `UNSUPPORTED_MODELS`, but the precedence seemed worth getting right.

The list is also published as an `allowed_setpoints` attribute, so a dashboard can offer only values that take effect instead of a free slider the board silently ignores.

Two notes:

- This deliberately does **not** change what gets sent. Snapping on the way out belongs in pytboss, and I've proposed it there (dknowles2/pytboss#506) since the current clamp is Fahrenheit-only and would undo any snapping done here.
- If the `accepted_setpoints()` from that issue lands, the coordinator method here becomes a one-line delegate. I kept the derivation local so this doesn't have to wait on a pytboss release.