### PR TITLE
Leave the setpoint alone when turning the grill off

### DIFF
--- a/custom_components/pitboss/climate.py
+++ b/custom_components/pitboss/climate.py
@@ -99,8 +99,10 @@ class GrillClimate(BaseEntity, ClimateEntity):
 
     async def async_turn_off(self) -> None:
         """Turn off the grill."""
+        # Deliberately does not touch the setpoint. It is the user's
+        # setting, it has no effect while the grill is off, and it is what
+        # the grill will use next time it is lit.
         await self.coordinator.api.turn_grill_off()
-        await self.async_set_temperature(temperature=self.coordinator.api.spec.min_temp)
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set the HVAC mode."""

--- a/custom_components/pitboss/switch.py
+++ b/custom_components/pitboss/switch.py
@@ -13,7 +13,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DEFAULT_MIN_TEMP, DOMAIN, LOGGER
+from .const import DOMAIN, LOGGER
 from .coordinator import PitBossDataUpdateCoordinator
 from .entity import BaseEntity
 
@@ -68,10 +68,8 @@ class PowerSwitch(BaseSwitchEntity):
 
     async def async_turn_off(self, **_: Any) -> None:
         """Turn off the switch."""
+        # See GrillClimate.async_turn_off: the setpoint is left alone.
         await self.coordinator.api.turn_grill_off()
-        await self.coordinator.api.set_grill_temperature(
-            temp=self.coordinator.api.spec.min_temp or DEFAULT_MIN_TEMP
-        )
 
 
 class PrimerSwitch(BaseSwitchEntity):

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -154,7 +154,8 @@ async def test_turn_off(
         blocking=True,
     )
     mock_pitboss.turn_grill_off.assert_awaited_once()
-    mock_pitboss.set_grill_temperature.assert_awaited_once_with(130)
+    # The setpoint belongs to the user; turning off must not rewrite it.
+    mock_pitboss.set_grill_temperature.assert_not_awaited()
 
 
 @pytest.mark.parametrize("model", ["PBV4PS2"])

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -94,7 +94,8 @@ async def test_power_switch_turn_off(
         blocking=True,
     )
     mock_pitboss.turn_grill_off.assert_awaited_once()
-    mock_pitboss.set_grill_temperature.assert_awaited_once_with(temp=130)
+    # The setpoint belongs to the user; turning off must not rewrite it.
+    mock_pitboss.set_grill_temperature.assert_not_awaited()
 
 
 @pytest.mark.parametrize("model", ["PBV4PS2"])


### PR DESCRIPTION
Set 2 of #321. Independent of #326 and #327; all three are against `main` (see the note in #327 about fork stacking).

Both turn-off paths wrote `spec.min_temp` to the grill afterwards. That value is always Fahrenheit, so on a grill running in Celsius it set the setpoint to **180 °C** — and even where the unit matched, it silently discarded whatever the user had dialled in. I lost my own setpoint to this a few times before working out where it went.

My first instinct was to fix the unit, but the setpoint has no effect while the grill is off and is exactly what the grill uses next time it is lit, so there is nothing to reset. Removing the write fixes the unit bug, stops the data loss, and is a smaller diff than getting the conversion right would be.

Happy to do it the other way if you'd rather keep the reset and just correct the unit — though that one can't be made correct on Celsius grills until the pytboss clamp is fixed.