### PR TITLE
Expose the fan and igniter as binary sensors

### DIFF
--- a/custom_components/pitboss/binary_sensor.py
+++ b/custom_components/pitboss/binary_sensor.py
@@ -35,6 +35,8 @@ class PBBinarySensorEntityDescription(BinarySensorEntityDescription):
         "motorErr",
         "noPellets",
         "motorState",
+        "fanState",
+        "hotState",
     ]
     device_class: BinarySensorDeviceClass | None = BinarySensorDeviceClass.PROBLEM
     entity_category: EntityCategory | None = EntityCategory.DIAGNOSTIC
@@ -92,6 +94,20 @@ ENTITY_DESCRIPTIONS = (
         device_class=BinarySensorDeviceClass.RUNNING,
         entity_category=None,
         icon="mdi:filter-cog",
+    ),
+    PBBinarySensorEntityDescription(
+        key="fanState",
+        name="Fan",
+        device_class=BinarySensorDeviceClass.RUNNING,
+        entity_category=None,
+        icon="mdi:fan",
+    ),
+    PBBinarySensorEntityDescription(
+        key="hotState",
+        name="Igniter",
+        device_class=BinarySensorDeviceClass.RUNNING,
+        entity_category=None,
+        icon="mdi:fire",
     ),
 )
 

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -56,3 +56,21 @@ async def test_is_on_with_data(
     assert auger is not None
     assert probe_1_error.state == "on"
     assert auger.state == "off"
+
+
+async def test_fan_and_igniter_report_their_state(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+) -> None:
+    """Both are already decoded by pytboss; they just were not exposed."""
+    entry = await mock_add_config_entry()
+    coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator.async_set_updated_data({"fanState": True, "hotState": False})
+    await hass.async_block_till_done()
+
+    fan = hass.states.get(_entity_id("Fan"))
+    igniter = hass.states.get(_entity_id("Igniter"))
+    assert fan is not None
+    assert igniter is not None
+    assert fan.state == "on"
+    assert igniter.state == "off"


### PR DESCRIPTION
Set 3 of #321. Independent of #330; both are against `main`.

pytboss already decodes `fanState` and `hotState` out of the status frame, and the integration already surfaces `motorState` right next to them — these two just were never wired up.

Both are genuinely useful during a cook: the igniter tells you the grill is still lighting rather than holding temperature, and the fan running while the module is off is the shutdown cycle rather than a fault. `GrillClimate.hvac_action` already reads both for exactly that distinction, so the data was being used, just not shown.

Same shape as the existing `Auger` entity. The existing `test_creates_all_entities` covers them automatically; added one more for the reported state.