### PR TITLE
Add a connectivity binary sensor

### DIFF
--- a/custom_components/pitboss/binary_sensor.py
+++ b/custom_components/pitboss/binary_sensor.py
@@ -117,10 +117,11 @@ async def async_setup_entry(
 ):
     """Setup binary_sensor platform."""
     coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
-    entities: list[BinarySensor] = []
+    entities: list[BinarySensorEntity] = []
     assert entry.unique_id is not None
     for entity_description in ENTITY_DESCRIPTIONS:
         entities.append(BinarySensor(coordinator, entry.unique_id, entity_description))
+    entities.append(ConnectivitySensor(coordinator, entry.unique_id))
     async_add_entities(entities)
 
 
@@ -144,3 +145,32 @@ class BinarySensor(BaseEntity, BinarySensorEntity):
         if data := self.coordinator.data:
             return data.get(self.entity_description.key)
         return None
+
+
+class ConnectivitySensor(BaseEntity, BinarySensorEntity):
+    """Reports whether the grill is currently reachable.
+
+    Unlike every other entity this one stays available while the grill is
+    disconnected: an entity that disappears cannot say the grill is offline,
+    which is the one thing an offline automation needs to hear.
+    """
+
+    _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(
+        self,
+        coordinator: PitBossDataUpdateCoordinator,
+        entry_unique_id: str,
+    ) -> None:
+        super().__init__(coordinator, entry_unique_id)
+        self._attr_unique_id = f"connectivity_{entry_unique_id}"
+        self._attr_name = "Connectivity"
+
+    @property
+    def available(self) -> bool:
+        return True
+
+    @property
+    def is_on(self) -> bool:
+        return bool(self.coordinator.api) and self.coordinator.api.is_connected()

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -1,4 +1,5 @@
 from collections.abc import Awaitable, Callable
+from unittest.mock import Mock
 
 import pytest
 from conftest import get_entity
@@ -74,3 +75,26 @@ async def test_fan_and_igniter_report_their_state(
     assert igniter is not None
     assert fan.state == "on"
     assert igniter.state == "off"
+
+
+async def test_connectivity_reports_offline_instead_of_vanishing(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+    mock_pitboss: Mock,
+) -> None:
+    """It must stay available while disconnected, or it can't say so."""
+    entry = await mock_add_config_entry()
+    coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    mock_pitboss.is_connected.return_value = True
+    coordinator.async_set_updated_data({})
+    await hass.async_block_till_done()
+    state = hass.states.get(_entity_id("Connectivity"))
+    assert state is not None
+    assert state.state == "on"
+
+    mock_pitboss.is_connected.return_value = False
+    coordinator.async_set_updated_data({})
+    await hass.async_block_till_done()
+    state = hass.states.get(_entity_id("Connectivity"))
+    assert state is not None
+    assert state.state == "off"


### PR DESCRIPTION
Set 3 of #321. Independent of #329.

Every entity goes unavailable when the grill drops, which leaves nothing to build a "grill is offline" automation on — an entity that vanishes cannot report the state you want to trigger on.

This one deliberately overrides `available` to stay `True` and reports `api.is_connected()` instead. That is the opposite of the convention everywhere else in the integration, which is the point, so I've said why in the docstring rather than leaving it to look like an oversight.

I've been running it for about a month across all three transports — it only calls `is_connected()`, which every transport implements, so it behaves the same on BLE, cloud and a local connection.

One known limitation, not addressed here: if the grill is unreachable at startup the whole config entry is still in setup-retry, so this sensor is unavailable along with everything else. It works for connected-then-dropped, which is the case worth automating on.