### PR TITLE
Add a firmware version sensor

### DIFF
--- a/custom_components/pitboss/__init__.py
+++ b/custom_components/pitboss/__init__.py
@@ -125,6 +125,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         await pitboss.stop()
         raise
 
+    if coordinator.firmware_version:
+        coordinator.device_info["sw_version"] = coordinator.firmware_version
+
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
 

--- a/custom_components/pitboss/coordinator.py
+++ b/custom_components/pitboss/coordinator.py
@@ -20,6 +20,7 @@ class PitBossDataUpdateCoordinator(DataUpdateCoordinator[StateDict]):
     config_entry: ConfigEntry
     device_info: DeviceInfo
     api: PitBoss
+    firmware_version: str | None = None
 
     def __init__(
         self,
@@ -56,6 +57,12 @@ class PitBossDataUpdateCoordinator(DataUpdateCoordinator[StateDict]):
         """Set up the coordinator."""
         await self.api.subscribe_state(self._on_state_update)
         await self._start_api()
+        try:
+            result = await self.api.get_firmware_version()
+            self.firmware_version = result.get("firmwareVersion")
+        except Exception as ex:  # noqa: BLE001
+            # Cosmetic; never worth failing setup over.
+            self.logger.debug("Could not fetch the firmware version: %s", ex)
 
     def _merge_state(self, state: StateDict) -> StateDict:
         """Fold a state frame onto the last known one.

--- a/custom_components/pitboss/sensor.py
+++ b/custom_components/pitboss/sensor.py
@@ -8,7 +8,7 @@ from typing import Literal
 from homeassistant.components.sensor import SensorEntity, SensorEntityDescription
 from homeassistant.components.sensor.const import SensorDeviceClass, SensorStateClass
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import UnitOfTemperature, UnitOfTime
+from homeassistant.const import EntityCategory, UnitOfTemperature, UnitOfTime
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -86,10 +86,12 @@ async def async_setup_entry(
     """Setup sensor platform."""
     coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
     assert entry.unique_id is not None
-    entities: list[BaseSensorEntity] = []
+    entities: list[SensorEntity] = []
     entity_description: PBSensorEntityDescription
     for entity_description in PROBE_ENTITY_DESCRIPTIONS:
         entities.append(ProbeSensor(coordinator, entry.unique_id, entity_description))
+    if coordinator.firmware_version:
+        entities.append(FirmwareSensor(coordinator, entry.unique_id))
     if coordinator.api.spec.json.get("has_recipe_functionality", False):
         for entity_description in RECIPE_ENTITY_DESCRIPTIONS:
             entities.append(
@@ -172,3 +174,29 @@ class RecipeSensor(BaseSensorEntity):
         if data := self.coordinator.data:
             return data.get("moduleIsOn", True) and super().available
         return super().available
+
+
+class FirmwareSensor(BaseEntity, SensorEntity):
+    """The firmware version running on the control board."""
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_icon = "mdi:chip"
+
+    def __init__(
+        self,
+        coordinator: PitBossDataUpdateCoordinator,
+        entry_unique_id: str,
+    ) -> None:
+        super().__init__(coordinator, entry_unique_id)
+        self._attr_unique_id = f"firmware_{entry_unique_id}"
+        self._attr_name = "Firmware version"
+
+    @property
+    def available(self) -> bool:
+        # Read once at setup and unchanging, so it stays readable while the
+        # grill is away rather than following the connection.
+        return self.coordinator.firmware_version is not None
+
+    @property
+    def native_value(self) -> str | None:
+        return self.coordinator.firmware_version

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,9 +1,11 @@
 from collections.abc import Awaitable, Callable
 from typing import cast
+from unittest.mock import Mock
 
 import pytest
 from conftest import get_entity
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
 from pytboss.grills import StateDict
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -111,3 +113,34 @@ async def test_native_value_none_without_data(
     await mock_add_config_entry()
     entity = get_entity(hass, "sensor", "sensor.mygrill_probe_1", ProbeSensor)
     assert entity.native_value is None
+
+
+@pytest.mark.parametrize("model", ["PBV4PS2"])
+async def test_firmware_version_sensor(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+    mock_pitboss: Mock,
+) -> None:
+    """Read once at setup, and reported on the device too."""
+    mock_pitboss.get_firmware_version.return_value = {"firmwareVersion": "0.5.7"}
+    await mock_add_config_entry()
+
+    state = hass.states.get("sensor.mygrill_firmware_version")
+    assert state is not None
+    assert state.state == "0.5.7"
+
+    device = dr.async_get(hass).async_get_device({(DOMAIN, "mygrill")})
+    assert device is not None
+    assert device.sw_version == "0.5.7"
+
+
+@pytest.mark.parametrize("model", ["PBV4PS2"])
+async def test_no_firmware_sensor_when_the_grill_does_not_answer(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+    mock_pitboss: Mock,
+) -> None:
+    """A failed read must not break setup, and creates no entity."""
+    mock_pitboss.get_firmware_version.side_effect = RuntimeError("nope")
+    await mock_add_config_entry()
+    assert hass.states.get("sensor.mygrill_firmware_version") is None


### PR DESCRIPTION
Set 4 of #321. Independent of #332 and #333 — verified they merge cleanly against each other in any order.

pytboss exposes `get_firmware_version()` and the device page has a `sw_version` field for exactly this, but neither was used, so the device showed no firmware at all.

Read once during coordinator setup and surfaced both as a diagnostic sensor and on the device itself. The read is best-effort: a grill that does not answer simply gets no sensor rather than failing setup, which is covered by a test.

Unlike the other entities this one does not follow the connection — the value is read once and cannot change while the grill is away, so it stays readable rather than going unavailable.