### PR TITLE
Add controller uptime and free memory diagnostics

### DIFF
--- a/custom_components/pitboss/const.py
+++ b/custom_components/pitboss/const.py
@@ -9,6 +9,8 @@ NAME = "PitBoss"
 DOMAIN = "pitboss"
 MANUFACTURER = NAME
 PING_INTERVAL = timedelta(seconds=30)
+# Diagnostics change slowly; no need to read them at the poll rate.
+SYS_INFO_INTERVAL = 60.0
 PROTOCOL_WSS = "wss"
 PROTOCOL_BLE = "ble"
 ALL_PROTOCOLS = (PROTOCOL_BLE, PROTOCOL_WSS)

--- a/custom_components/pitboss/coordinator.py
+++ b/custom_components/pitboss/coordinator.py
@@ -1,6 +1,7 @@
 """DataUpdateCoordinator for PitBoss."""
 
 from math import floor
+from time import monotonic
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfTemperature
@@ -11,7 +12,7 @@ from pytboss.api import PitBoss
 from pytboss.exceptions import GrillUnavailable, NotConnectedError, RPCError
 from pytboss.grills import StateDict
 
-from .const import DOMAIN, LOGGER, PING_INTERVAL
+from .const import DOMAIN, LOGGER, PING_INTERVAL, SYS_INFO_INTERVAL
 
 
 class PitBossDataUpdateCoordinator(DataUpdateCoordinator[StateDict]):
@@ -35,6 +36,9 @@ class PitBossDataUpdateCoordinator(DataUpdateCoordinator[StateDict]):
         self.device_info = device_info
         self.api = api
         self._api_started = False
+        # Latest Sys.GetInfo payload from the control board.
+        self.sys_info: dict = {}
+        self._sys_info_at = 0.0
 
     def accepted_setpoints(self, unit: str) -> list[float]:
         """Grill setpoints the control board honours, expressed in `unit`.
@@ -98,6 +102,21 @@ class PitBossDataUpdateCoordinator(DataUpdateCoordinator[StateDict]):
         except GrillUnavailable as ex:
             raise UpdateFailed("Grill unavailable") from ex
 
+    async def _async_refresh_sys_info(self) -> None:
+        """Refresh the control board's system info. Never fatal.
+
+        Uptime and free memory change slowly and are diagnostic, so they are
+        not worth a round trip on every poll.
+        """
+        now = monotonic()
+        if self.sys_info and now - self._sys_info_at < SYS_INFO_INTERVAL:
+            return
+        try:
+            self.sys_info = await self.api.config.get_info()
+            self._sys_info_at = now
+        except Exception as ex:  # noqa: BLE001
+            self.logger.debug("Could not fetch the system info: %s", ex)
+
     async def _async_update_data(self) -> StateDict:
         if not self._api_started:
             self.logger.debug("Starting API")
@@ -110,6 +129,8 @@ class PitBossDataUpdateCoordinator(DataUpdateCoordinator[StateDict]):
             await self.api.ping(timeout=10.0)
         except NotConnectedError as ex:
             raise UpdateFailed("Grill not connected") from ex
+
+        await self._async_refresh_sys_info()
 
         # Always fetch the current state to ensure sensors stay up-to-date.
         # Relying solely on push notifications means sensors can go stale after

--- a/custom_components/pitboss/sensor.py
+++ b/custom_components/pitboss/sensor.py
@@ -8,7 +8,12 @@ from typing import Literal
 from homeassistant.components.sensor import SensorEntity, SensorEntityDescription
 from homeassistant.components.sensor.const import SensorDeviceClass, SensorStateClass
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import EntityCategory, UnitOfTemperature, UnitOfTime
+from homeassistant.const import (
+    EntityCategory,
+    UnitOfInformation,
+    UnitOfTemperature,
+    UnitOfTime,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -90,6 +95,8 @@ async def async_setup_entry(
     entity_description: PBSensorEntityDescription
     for entity_description in PROBE_ENTITY_DESCRIPTIONS:
         entities.append(ProbeSensor(coordinator, entry.unique_id, entity_description))
+    for description in SYS_INFO_DESCRIPTIONS:
+        entities.append(SysInfoSensor(coordinator, entry.unique_id, description))
     if coordinator.firmware_version:
         entities.append(FirmwareSensor(coordinator, entry.unique_id))
     if coordinator.api.spec.json.get("has_recipe_functionality", False):
@@ -200,3 +207,65 @@ class FirmwareSensor(BaseEntity, SensorEntity):
     @property
     def native_value(self) -> str | None:
         return self.coordinator.firmware_version
+
+
+@dataclass(frozen=True, kw_only=True)
+class SysInfoSensorEntityDescription(SensorEntityDescription):
+    """Describes a sensor backed by the control board's system info."""
+
+    # Key inside the Sys.GetInfo payload.
+    info_key: str
+    entity_category: EntityCategory = EntityCategory.DIAGNOSTIC
+
+
+SYS_INFO_DESCRIPTIONS = (
+    SysInfoSensorEntityDescription(
+        key="controller_uptime",
+        info_key="uptime",
+        name="Controller uptime",
+        icon="mdi:timer-outline",
+        device_class=SensorDeviceClass.DURATION,
+        native_unit_of_measurement=UnitOfTime.SECONDS,
+        suggested_display_precision=0,
+    ),
+    SysInfoSensorEntityDescription(
+        key="controller_free_memory",
+        info_key="ram_free",
+        name="Controller free memory",
+        icon="mdi:memory",
+        native_unit_of_measurement=UnitOfInformation.BYTES,
+        suggested_unit_of_measurement=UnitOfInformation.KILOBYTES,
+        device_class=SensorDeviceClass.DATA_SIZE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=0,
+    ),
+)
+
+
+class SysInfoSensor(BaseEntity, SensorEntity):
+    """Diagnostic sensor backed by the control board's system info."""
+
+    entity_description: SysInfoSensorEntityDescription
+
+    def __init__(
+        self,
+        coordinator: PitBossDataUpdateCoordinator,
+        entry_unique_id: str,
+        entity_description: SysInfoSensorEntityDescription,
+    ) -> None:
+        super().__init__(coordinator, entry_unique_id)
+        self.entity_description = entity_description
+        self._attr_unique_id = f"{entity_description.key}_{entry_unique_id}"
+
+    @property
+    def available(self) -> bool:
+        # Without the connection check these would keep reporting whatever
+        # was read before the grill went away.
+        return (
+            super().available
+            and self.entity_description.info_key in self.coordinator.sys_info
+        )
+
+    @property
+    def native_value(self):
+        return self.coordinator.sys_info.get(self.entity_description.info_key)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 from collections.abc import Awaitable, Callable, Generator
 from typing import TypeVar
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from homeassistant.const import CONF_DEVICE_ID, CONF_MODEL, CONF_PASSWORD, CONF_PROTOCOL
@@ -127,4 +127,8 @@ def mock_pitboss(spec: Grill) -> Generator[Mock]:
     with patch("pytboss.api.PitBoss", autospec=True) as mock_pitboss_cls:
         api = mock_pitboss_cls.return_value
         api.spec = spec
+        # `config` and `fs` are set in PitBoss.__init__, so autospec does not
+        # know about them.
+        api.config = Mock()
+        api.config.get_info = AsyncMock(return_value={})
         yield api

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -144,3 +144,37 @@ async def test_no_firmware_sensor_when_the_grill_does_not_answer(
     mock_pitboss.get_firmware_version.side_effect = RuntimeError("nope")
     await mock_add_config_entry()
     assert hass.states.get("sensor.mygrill_firmware_version") is None
+
+
+@pytest.mark.parametrize("model", ["PBV4PS2"])
+async def test_controller_diagnostics(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+    mock_pitboss: Mock,
+) -> None:
+    mock_pitboss.config.get_info.return_value = {"uptime": 3600, "ram_free": 61000}
+    entry = await mock_add_config_entry()
+    coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator.async_set_updated_data({"moduleIsOn": False})
+    await hass.async_block_till_done()
+
+    uptime = hass.states.get("sensor.mygrill_controller_uptime")
+    assert uptime is not None
+    assert uptime.state == "3600"
+
+
+@pytest.mark.parametrize("model", ["PBV4PS2"])
+async def test_controller_diagnostics_are_not_read_every_poll(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+    mock_pitboss: Mock,
+) -> None:
+    """They change slowly; a round trip per poll would be wasted."""
+    mock_pitboss.config.get_info.return_value = {"uptime": 3600, "ram_free": 61000}
+    entry = await mock_add_config_entry()
+    coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    mock_pitboss.config.get_info.reset_mock()
+
+    await coordinator._async_update_data()
+    await coordinator._async_update_data()
+    mock_pitboss.config.get_info.assert_not_awaited()


### PR DESCRIPTION
Set 4 of #321. Independent of #331 and #333.

The control board answers `Sys.GetInfo` with its own uptime and heap, reachable through the public `api.config.get_info()`.

Uptime is the one I actually wanted: a WiFi module that quietly reboots takes the connection with it, and without this there is nothing in Home Assistant that shows it happened. I lost about 32 minutes of a cook to exactly that before adding it — the uptime had dropped from ~47 hours to 1095 seconds, which is the only reason I know what happened.

Read at most once a minute rather than on every poll, since neither value changes fast. Both go unavailable with the connection so they cannot present a stale reading as current.