### PR TITLE
Name probe entities after the port on the controller

### DIFF
--- a/custom_components/pitboss/binary_sensor.py
+++ b/custom_components/pitboss/binary_sensor.py
@@ -45,17 +45,14 @@ class PBBinarySensorEntityDescription(BinarySensorEntityDescription):
 ENTITY_DESCRIPTIONS = (
     PBBinarySensorEntityDescription(
         key="err1",
-        name="Probe 1 error",
         icon="mdi:thermometer-alert",
     ),
     PBBinarySensorEntityDescription(
         key="err2",
-        name="Probe 2 error",
         icon="mdi:thermometer-alert",
     ),
     PBBinarySensorEntityDescription(
         key="err3",
-        name="Probe 3 error",
         icon="mdi:thermometer-alert",
     ),
     PBBinarySensorEntityDescription(
@@ -144,7 +141,7 @@ class BinarySensor(BaseEntity, BinarySensorEntity):
         self.entity_description = entity_description
         self._attr_unique_id = f"{entity_description.key}_{entry_unique_id}"
         # Name these after the physical port too, so a grill with an MPC does
-        # not report an "MP1 error" as "Probe 1 error".
+        # not report a "P2 error" as "Probe 2 error".
         probe_number = PROBE_ERROR_KEYS.get(entity_description.key)
         if probe_number is not None:
             self._attr_name = f"{probe_label(coordinator.has_mpc, probe_number)} error"

--- a/custom_components/pitboss/binary_sensor.py
+++ b/custom_components/pitboss/binary_sensor.py
@@ -15,7 +15,7 @@ from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN
+from .const import DOMAIN, probe_label
 from .coordinator import PitBossDataUpdateCoordinator
 from .entity import BaseEntity
 
@@ -112,6 +112,10 @@ ENTITY_DESCRIPTIONS = (
 )
 
 
+# The grill only reports errors for the first three probes.
+PROBE_ERROR_KEYS = {"err1": 1, "err2": 2, "err3": 3}
+
+
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ):
@@ -139,6 +143,11 @@ class BinarySensor(BaseEntity, BinarySensorEntity):
         super().__init__(coordinator, entry_unique_id)
         self.entity_description = entity_description
         self._attr_unique_id = f"{entity_description.key}_{entry_unique_id}"
+        # Name these after the physical port too, so a grill with an MPC does
+        # not report an "MP1 error" as "Probe 1 error".
+        probe_number = PROBE_ERROR_KEYS.get(entity_description.key)
+        if probe_number is not None:
+            self._attr_name = f"{probe_label(coordinator.has_mpc, probe_number)} error"
 
     @property
     def is_on(self) -> bool | None:

--- a/custom_components/pitboss/const.py
+++ b/custom_components/pitboss/const.py
@@ -24,13 +24,19 @@ DEFAULT_PROBE_CELSIUS_STEP = 1
 
 
 def probe_label(has_mpc: bool, probe_number: int) -> str:
-    """The label the controller prints next to a probe port.
+    """The label the vendor's own app prints next to a probe port.
 
-    Grills with a meat probe control port label their ports MPC, MP1, MP2 and
-    so on -- the control probe comes first, and the numbered ones start after
-    it. Matching that avoids an off-by-one between what the panel says and
-    what Home Assistant shows. Everything else just counts from 1.
+    Taken from `getProbeLabel` in the Pit Boss Android app (2.10.3), not
+    inferred: on a grill with a control port, protocol probe 1 is that port
+    and the rest keep their protocol number.
+
+    The app's `isMpcProbe(n, settings)` is `settings.hasMpc === true &&
+    n === 1`, so probe 1 -- and only probe 1 -- is the control probe. Its
+    label is `mpcType.toUpperCase()`, defaulting to `MPC`. Every other probe
+    falls through to `"P" + n`, which is why the numbering does not shift.
+
+    Grills without a control port keep the name they have today.
     """
     if not has_mpc:
         return f"Probe {probe_number}"
-    return "MPC" if probe_number == 1 else f"MP{probe_number - 1}"
+    return "MPC" if probe_number == 1 else f"P{probe_number}"

--- a/custom_components/pitboss/const.py
+++ b/custom_components/pitboss/const.py
@@ -21,3 +21,16 @@ DEFAULT_PROBE_MIN_TEMP = 50
 DEFAULT_PROBE_MAX_TEMP = 250
 DEFAULT_PROBE_FAHRENHEIT_STEP = 1
 DEFAULT_PROBE_CELSIUS_STEP = 1
+
+
+def probe_label(has_mpc: bool, probe_number: int) -> str:
+    """The label the controller prints next to a probe port.
+
+    Grills with a meat probe control port label their ports MPC, MP1, MP2 and
+    so on -- the control probe comes first, and the numbered ones start after
+    it. Matching that avoids an off-by-one between what the panel says and
+    what Home Assistant shows. Everything else just counts from 1.
+    """
+    if not has_mpc:
+        return f"Probe {probe_number}"
+    return "MPC" if probe_number == 1 else f"MP{probe_number - 1}"

--- a/custom_components/pitboss/coordinator.py
+++ b/custom_components/pitboss/coordinator.py
@@ -57,6 +57,11 @@ class PitBossDataUpdateCoordinator(DataUpdateCoordinator[StateDict]):
             return [float(v) for v in celsius]
         return [float(floor((v - 32) / 1.8)) for v in fahrenheit]
 
+    @property
+    def has_mpc(self) -> bool:
+        """Whether the grill has a meat probe control port."""
+        return self.api.spec.has_mpc
+
     async def _async_setup(self) -> None:
         """Set up the coordinator."""
         await self.api.subscribe_state(self._on_state_update)

--- a/custom_components/pitboss/number.py
+++ b/custom_components/pitboss/number.py
@@ -37,14 +37,12 @@ class PitBossNumberEntityDescription(NumberEntityDescription):
 
 PROBE_1_DESCRIPTION = PitBossNumberEntityDescription(
     key="p1Target",
-    name="Probe 1 Target",
     probe_number=1,
     set_fn=lambda api: api.set_probe_temperature,
     matching_probe_key="p1Temp",
 )
 PROBE_2_DESCRIPTION = PitBossNumberEntityDescription(
     key="p2Target",
-    name="Probe 2 Target",
     probe_number=2,
     set_fn=lambda api: api.set_probe_2_temperature,
     matching_probe_key="p2Temp",

--- a/custom_components/pitboss/number.py
+++ b/custom_components/pitboss/number.py
@@ -19,6 +19,7 @@ from .const import (
     DEFAULT_PROBE_MAX_TEMP,
     DEFAULT_PROBE_MIN_TEMP,
     DOMAIN,
+    probe_label,
 )
 from .coordinator import PitBossDataUpdateCoordinator
 from .entity import BaseEntity
@@ -27,6 +28,7 @@ from .entity import BaseEntity
 @dataclass(frozen=True, kw_only=True)
 class PitBossNumberEntityDescription(NumberEntityDescription):
     key: Literal["p1Target", "p2Target"]
+    probe_number: Literal[1, 2]
     set_fn: Callable[[PitBoss], Callable[[int], Awaitable[dict]]]
     device_class: NumberDeviceClass = NumberDeviceClass.TEMPERATURE
     icon: str = "mdi:thermometer"
@@ -36,12 +38,14 @@ class PitBossNumberEntityDescription(NumberEntityDescription):
 PROBE_1_DESCRIPTION = PitBossNumberEntityDescription(
     key="p1Target",
     name="Probe 1 Target",
+    probe_number=1,
     set_fn=lambda api: api.set_probe_temperature,
     matching_probe_key="p1Temp",
 )
 PROBE_2_DESCRIPTION = PitBossNumberEntityDescription(
     key="p2Target",
     name="Probe 2 Target",
+    probe_number=2,
     set_fn=lambda api: api.set_probe_2_temperature,
     matching_probe_key="p2Temp",
 )
@@ -80,6 +84,8 @@ class TargetProbeTemperature(BaseEntity, NumberEntity):
         super().__init__(coordinator, entry_unique_id)
         self.entity_description: PitBossNumberEntityDescription = entity_description
         self._attr_unique_id = f"{entity_description.key}_{entry_unique_id}"
+        label = probe_label(coordinator.has_mpc, entity_description.probe_number)
+        self._attr_name = f"{label} target"
 
     @property
     def native_unit_of_measurement(self) -> UnitOfTemperature | None:

--- a/custom_components/pitboss/sensor.py
+++ b/custom_components/pitboss/sensor.py
@@ -36,22 +36,18 @@ class ProbeSensorEntityDescription(SensorEntityDescription):
 PROBE_ENTITY_DESCRIPTIONS = (
     ProbeSensorEntityDescription(
         key="p1Temp",
-        name="Probe 1",
         probe_number=1,
     ),
     ProbeSensorEntityDescription(
         key="p2Temp",
-        name="Probe 2",
         probe_number=2,
     ),
     ProbeSensorEntityDescription(
         key="p3Temp",
-        name="Probe 3",
         probe_number=3,
     ),
     ProbeSensorEntityDescription(
         key="p4Temp",
-        name="Probe 4",
         probe_number=4,
     ),
 )

--- a/custom_components/pitboss/sensor.py
+++ b/custom_components/pitboss/sensor.py
@@ -17,7 +17,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN
+from .const import DOMAIN, probe_label
 from .coordinator import PitBossDataUpdateCoordinator
 from .entity import BaseEntity
 
@@ -143,6 +143,7 @@ class ProbeSensor(BaseSensorEntity):
         super().__init__(coordinator, entry_unique_id, entity_description)
         self.probe_number = self.entity_description.probe_number
         self._attr_unique_id = f"probe{self.probe_number}_{entry_unique_id}"
+        self._attr_name = probe_label(coordinator.has_mpc, self.probe_number)
 
     @property
     def entity_registry_enabled_default(self) -> bool:

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -6,8 +6,12 @@ from conftest import get_entity
 from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.pitboss.binary_sensor import ENTITY_DESCRIPTIONS, BinarySensor
-from custom_components.pitboss.const import DOMAIN
+from custom_components.pitboss.binary_sensor import (
+    ENTITY_DESCRIPTIONS,
+    PROBE_ERROR_KEYS,
+    BinarySensor,
+)
+from custom_components.pitboss.const import DOMAIN, probe_label
 from custom_components.pitboss.coordinator import PitBossDataUpdateCoordinator
 
 pytestmark = pytest.mark.parametrize("model", ["PBV4PS2"])
@@ -24,7 +28,11 @@ async def test_creates_all_entities(
     await mock_add_config_entry()
     for description in ENTITY_DESCRIPTIONS:
         assert isinstance(description.name, str)
-        entity_id = _entity_id(description.name)
+        name = description.name
+        # The probe error sensors are renamed after the physical port.
+        if (probe_number := PROBE_ERROR_KEYS.get(description.key)) is not None:
+            name = f"{probe_label(True, probe_number)} error"
+        entity_id = _entity_id(name)
         assert hass.states.get(entity_id) is not None, entity_id
 
 
@@ -33,13 +41,11 @@ async def test_is_on_no_data(
     mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
 ) -> None:
     await mock_add_config_entry()
-    state = hass.states.get(_entity_id("Probe 1 error"))
+    state = hass.states.get(_entity_id("MPC error"))
     assert state is not None
     assert state.state == "unavailable"
 
-    entity = get_entity(
-        hass, "binary_sensor", _entity_id("Probe 1 error"), BinarySensor
-    )
+    entity = get_entity(hass, "binary_sensor", _entity_id("MPC error"), BinarySensor)
     assert entity.is_on is None
 
 
@@ -51,7 +57,7 @@ async def test_is_on_with_data(
     coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
     coordinator.async_set_updated_data({"err1": True, "motorState": False})
     await hass.async_block_till_done()
-    probe_1_error = hass.states.get(_entity_id("Probe 1 error"))
+    probe_1_error = hass.states.get(_entity_id("MPC error"))
     auger = hass.states.get(_entity_id("Auger"))
     assert probe_1_error is not None
     assert auger is not None

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -11,7 +11,7 @@ from custom_components.pitboss.binary_sensor import (
     PROBE_ERROR_KEYS,
     BinarySensor,
 )
-from custom_components.pitboss.const import DOMAIN, probe_label
+from custom_components.pitboss.const import DOMAIN
 from custom_components.pitboss.coordinator import PitBossDataUpdateCoordinator
 
 pytestmark = pytest.mark.parametrize("model", ["PBV4PS2"])
@@ -21,17 +21,24 @@ def _entity_id(name: str) -> str:
     return f"binary_sensor.mygrill_{name.lower().replace(' ', '_')}"
 
 
+# Spelled out rather than computed with `probe_label`, so that a wrong label
+# is a test failure instead of a quietly updated expectation.
+PROBE_ERROR_NAMES = {"err1": "MPC error", "err2": "P2 error", "err3": "P3 error"}
+
+
 async def test_creates_all_entities(
     hass: HomeAssistant,
     mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
 ) -> None:
     await mock_add_config_entry()
     for description in ENTITY_DESCRIPTIONS:
-        assert isinstance(description.name, str)
-        name = description.name
-        # The probe error sensors are renamed after the physical port.
-        if (probe_number := PROBE_ERROR_KEYS.get(description.key)) is not None:
-            name = f"{probe_label(True, probe_number)} error"
+        # The probe error sensors carry no description name: the entity sets
+        # `_attr_name` from the port label, which takes precedence anyway.
+        if description.key in PROBE_ERROR_KEYS:
+            name = PROBE_ERROR_NAMES[description.key]
+        else:
+            assert isinstance(description.name, str)
+            name = description.name
         entity_id = _entity_id(name)
         assert hass.states.get(entity_id) is not None, entity_id
 

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -18,7 +18,7 @@ async def test_only_probe_1_entity_created(
 ) -> None:
     await mock_add_config_entry()
     assert hass.states.get("number.mygrill_mpc_target") is not None
-    assert hass.states.get("number.mygrill_mp1_target") is None
+    assert hass.states.get("number.mygrill_p2_target") is None
 
 
 @pytest.mark.parametrize("model", ["PB1150PS3"])

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -17,8 +17,8 @@ async def test_only_probe_1_entity_created(
     mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
 ) -> None:
     await mock_add_config_entry()
-    assert hass.states.get("number.mygrill_probe_1_target") is not None
-    assert hass.states.get("number.mygrill_probe_2_target") is None
+    assert hass.states.get("number.mygrill_mpc_target") is not None
+    assert hass.states.get("number.mygrill_mp1_target") is None
 
 
 @pytest.mark.parametrize("model", ["PB1150PS3"])
@@ -26,6 +26,7 @@ async def test_both_probe_entities_created(
     hass: HomeAssistant,
     mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
 ) -> None:
+    """This grill has no MPC, so the ports keep their plain numbering."""
     await mock_add_config_entry()
     assert hass.states.get("number.mygrill_probe_1_target") is not None
     assert hass.states.get("number.mygrill_probe_2_target") is not None
@@ -52,7 +53,7 @@ async def test_native_value_and_availability(
     # No matching probe temperature reported: entity unavailable.
     coordinator.async_set_updated_data({"p1Target": 165, "isFahrenheit": True})
     await hass.async_block_till_done()
-    state = hass.states.get("number.mygrill_probe_1_target")
+    state = hass.states.get("number.mygrill_mpc_target")
     assert state is not None
     assert state.state == "unavailable"
 
@@ -60,7 +61,7 @@ async def test_native_value_and_availability(
         {"p1Target": 165, "p1Temp": 70, "isFahrenheit": True}
     )
     await hass.async_block_till_done()
-    state = hass.states.get("number.mygrill_probe_1_target")
+    state = hass.states.get("number.mygrill_mpc_target")
     assert state is not None
     assert state.state == "165"
     assert state.attributes["unit_of_measurement"] == "°F"
@@ -85,7 +86,7 @@ async def test_set_native_value(
     await hass.services.async_call(
         "number",
         "set_value",
-        {"entity_id": "number.mygrill_probe_1_target", "value": 180},
+        {"entity_id": "number.mygrill_mpc_target", "value": 180},
         blocking=True,
     )
     mock_pitboss.set_probe_temperature.assert_awaited_once_with(180)
@@ -98,6 +99,6 @@ async def test_native_value_none_without_data(
 ) -> None:
     await mock_add_config_entry()
     entity = get_entity(
-        hass, "number", "number.mygrill_probe_1_target", TargetProbeTemperature
+        hass, "number", "number.mygrill_mpc_target", TargetProbeTemperature
     )
     assert entity.native_value is None

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -25,8 +25,8 @@ async def test_probe_sensors_enabled_by_meat_probes(
     await mock_add_config_entry()
     registry = er.async_get(hass)
     assert hass.states.get("sensor.mygrill_mpc") is not None
-    assert hass.states.get("sensor.mygrill_mp1") is not None
-    assert hass.states.get("sensor.mygrill_mp2") is None
+    assert hass.states.get("sensor.mygrill_p2") is not None
+    assert hass.states.get("sensor.mygrill_p3") is None
     assert hass.states.get("sensor.mygrill_probe_4") is None
     entity_id = registry.async_get_entity_id("sensor", DOMAIN, "probe3_mygrillid")
     assert entity_id is not None
@@ -185,7 +185,7 @@ async def test_probes_keep_plain_numbering_without_mpc(
     hass: HomeAssistant,
     mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
 ) -> None:
-    """Only grills with a control port get the MPC/MP1 naming."""
+    """Only grills with a control port get the MPC/P2 naming."""
     await mock_add_config_entry()
     assert hass.states.get("sensor.mygrill_probe_1") is not None
     assert hass.states.get("sensor.mygrill_mpc") is None

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -27,7 +27,7 @@ async def test_probe_sensors_enabled_by_meat_probes(
     assert hass.states.get("sensor.mygrill_mpc") is not None
     assert hass.states.get("sensor.mygrill_p2") is not None
     assert hass.states.get("sensor.mygrill_p3") is None
-    assert hass.states.get("sensor.mygrill_probe_4") is None
+    assert hass.states.get("sensor.mygrill_p4") is None
     entity_id = registry.async_get_entity_id("sensor", DOMAIN, "probe3_mygrillid")
     assert entity_id is not None
     entry = registry.async_get(entity_id)

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -24,9 +24,9 @@ async def test_probe_sensors_enabled_by_meat_probes(
     # probes 3-4 are registered but disabled.
     await mock_add_config_entry()
     registry = er.async_get(hass)
-    assert hass.states.get("sensor.mygrill_probe_1") is not None
-    assert hass.states.get("sensor.mygrill_probe_2") is not None
-    assert hass.states.get("sensor.mygrill_probe_3") is None
+    assert hass.states.get("sensor.mygrill_mpc") is not None
+    assert hass.states.get("sensor.mygrill_mp1") is not None
+    assert hass.states.get("sensor.mygrill_mp2") is None
     assert hass.states.get("sensor.mygrill_probe_4") is None
     entity_id = registry.async_get_entity_id("sensor", DOMAIN, "probe3_mygrillid")
     assert entity_id is not None
@@ -66,14 +66,14 @@ async def test_probe_native_value_and_unit(
     coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
     coordinator.async_set_updated_data({"p1Temp": 165, "isFahrenheit": True})
     await hass.async_block_till_done()
-    state = hass.states.get("sensor.mygrill_probe_1")
+    state = hass.states.get("sensor.mygrill_mpc")
     assert state is not None
     assert state.state == "165"
     assert state.attributes["unit_of_measurement"] == "°F"
 
     coordinator.async_set_updated_data({"p1Temp": 74, "isFahrenheit": False})
     await hass.async_block_till_done()
-    state = hass.states.get("sensor.mygrill_probe_1")
+    state = hass.states.get("sensor.mygrill_mpc")
     assert state is not None
     assert state.state == "165.2"
     assert state.attributes["unit_of_measurement"] == "°F"
@@ -111,7 +111,7 @@ async def test_native_value_none_without_data(
     mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
 ) -> None:
     await mock_add_config_entry()
-    entity = get_entity(hass, "sensor", "sensor.mygrill_probe_1", ProbeSensor)
+    entity = get_entity(hass, "sensor", "sensor.mygrill_mpc", ProbeSensor)
     assert entity.native_value is None
 
 
@@ -178,3 +178,14 @@ async def test_controller_diagnostics_are_not_read_every_poll(
     await coordinator._async_update_data()
     await coordinator._async_update_data()
     mock_pitboss.config.get_info.assert_not_awaited()
+
+
+@pytest.mark.parametrize("model", ["PB2180LK"])
+async def test_probes_keep_plain_numbering_without_mpc(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+) -> None:
+    """Only grills with a control port get the MPC/MP1 naming."""
+    await mock_add_config_entry()
+    assert hass.states.get("sensor.mygrill_probe_1") is not None
+    assert hass.states.get("sensor.mygrill_mpc") is None


### PR DESCRIPTION
Set 6 of #321, first of three. Independent of #331 and #332.

Grills with a meat probe control port label protocol probe 1 **MPC** and leave the rest as **P2, P3, P4**. Home Assistant calls them Probe 1..4, so the control port — the only probe the grill actually acts on — is shown as "Probe 1", indistinguishable from a plain meat probe.

That is a real trap rather than a cosmetic one: someone setting a target on "Probe 1" expecting the grill to act on it is right, and someone setting one on "Probe 2" expecting the same is wrong, with nothing in the UI to tell them apart.

Applied to the probe temperature sensors, their error sensors and the target numbers, and gated on `has_mpc` so grills without a control port keep the plain numbering they have today. There is a test for that case.

**Source.** The labels are taken from `getProbeLabel` in the Pit Boss Android app 2.10.3, not inferred from panel photos. `isMpcProbe(n, settings)` is `settings.hasMpc === true && n === 1`, and every other probe falls through to `"P" + n`. Full derivation, including the two unreachable branches, in [this comment](https://github.com/dknowles2/ha-pitboss/pull/333#issuecomment-5159199738).

An earlier revision of this PR labelled the remaining ports MP1, MP2, MP3 on the assumption that the numbering restarted after the control port. It does not — the vendor keeps the protocol index. That was interpretation on my part and it is gone.

Three notes:

- This **renames entities** on grills that have an MPC. Existing installs keep their entity ids — the registry does not rewrite them — but will show the new names; new installs get entity ids derived from them. Happy to drop it if you'd rather not have that churn.
- It also changes the *displayed* name on grills **without** an MPC, from "Probe 1 Target" to "Probe 1 target" — the port labels go through one helper and it produces sentence case. Entity ids are unaffected. Sentence case is the Home Assistant convention so I have left it, but it is a change and the description previously did not admit to it.
- `has_mpc` is read from the typed `spec.has_mpc`, which needs pytboss ≥ 2026.8.2. `manifest.json` still pins 2026.8.1, so this is blocked on #339.
