### PR TITLE
Add a set_grill_password action

### DIFF
--- a/custom_components/pitboss/__init__.py
+++ b/custom_components/pitboss/__init__.py
@@ -22,6 +22,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.typing import ConfigType
 from pytboss import api, ble, wss
 from pytboss.transport import Transport
 
@@ -34,6 +35,7 @@ from .const import (
     PROTOCOL_WSS,
 )
 from .coordinator import PitBossDataUpdateCoordinator
+from .services import async_register_services
 
 PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,
@@ -83,6 +85,16 @@ async def _connect_ble(
         raise ConfigEntryNotReady
 
     return conn
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up the integration.
+
+    Actions belong to the integration rather than to any one grill, so they
+    are registered once here instead of per config entry.
+    """
+    async_register_services(hass)
+    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/pitboss/services.py
+++ b/custom_components/pitboss/services.py
@@ -1,0 +1,82 @@
+"""Services for pitboss."""
+
+from __future__ import annotations
+
+import voluptuous as vol
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import ATTR_DEVICE_ID, CONF_PASSWORD
+from homeassistant.core import HomeAssistant, ServiceCall, callback
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import device_registry as dr
+
+from .const import DOMAIN, LOGGER
+from .coordinator import PitBossDataUpdateCoordinator
+
+SERVICE_SET_GRILL_PASSWORD = "set_grill_password"
+
+SET_GRILL_PASSWORD_SCHEMA = vol.Schema(
+    {
+        vol.Required(ATTR_DEVICE_ID): cv.string,
+        # Omit (or pass an empty string) to remove the password.
+        vol.Optional(CONF_PASSWORD, default=""): cv.string,
+    }
+)
+
+
+def _coordinator_for_device(
+    hass: HomeAssistant, device_id: str
+) -> tuple[PitBossDataUpdateCoordinator, ConfigEntry]:
+    """Return the coordinator and config entry for a PitBoss device.
+
+    Returns the entry itself rather than its id so the caller cannot end up
+    holding one without the other.
+    """
+    device = dr.async_get(hass).async_get(device_id)
+    if device is None:
+        raise ServiceValidationError(f"Unknown device: {device_id}")
+    for entry_id in device.config_entries:
+        coordinator = hass.data.get(DOMAIN, {}).get(entry_id)
+        entry = hass.config_entries.async_get_entry(entry_id)
+        if coordinator is not None and entry is not None:
+            return coordinator, entry
+    raise ServiceValidationError(f"Device {device_id} is not a PitBoss grill")
+
+
+async def _async_set_grill_password(hass: HomeAssistant, call: ServiceCall) -> None:
+    """Set or remove the grill password."""
+    coordinator, entry = _coordinator_for_device(hass, call.data[ATTR_DEVICE_ID])
+    new_password: str = call.data[CONF_PASSWORD]
+
+    if not coordinator.api.is_connected():
+        raise HomeAssistantError(
+            "The grill is not connected; turn it on and try again."
+        )
+
+    try:
+        await coordinator.api.set_grill_password(new_password)
+    except Exception as ex:
+        raise HomeAssistantError(f"Could not set the grill password: {ex}") from ex
+
+    # Keep the config entry in sync, otherwise Home Assistant would reconnect
+    # with the old password after a restart and every command would be
+    # rejected by the grill.
+    hass.config_entries.async_update_entry(
+        entry, data={**entry.data, CONF_PASSWORD: new_password}
+    )
+    LOGGER.info("Grill password %s", "removed" if not new_password else "updated")
+
+
+@callback
+def async_register_services(hass: HomeAssistant) -> None:
+    """Register PitBoss services."""
+
+    async def handle_set_grill_password(call: ServiceCall) -> None:
+        await _async_set_grill_password(hass, call)
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_SET_GRILL_PASSWORD,
+        handle_set_grill_password,
+        schema=SET_GRILL_PASSWORD_SCHEMA,
+    )

--- a/custom_components/pitboss/services.yaml
+++ b/custom_components/pitboss/services.yaml
@@ -1,0 +1,12 @@
+set_grill_password:
+  fields:
+    device_id:
+      required: true
+      selector:
+        device:
+          integration: pitboss
+    password:
+      required: false
+      selector:
+        text:
+          type: password

--- a/custom_components/pitboss/translations/en.json
+++ b/custom_components/pitboss/translations/en.json
@@ -1,55 +1,71 @@
 {
-    "title": "PitBoss",
-    "config": {
-        "abort": {
-            "already_configured": "Grill is already configured",
-            "reconfigure_successful": "Re-configuration was successful",
-            "unknown_grill": "Unknown grill type: {control_board}"
-        },
-        "step": {
-            "bluetooth_confirm": {
-                "description": "Do you want to set up {name}?"
-            },
-            "user": {
-                "description": "The Grill ID can be found in the PitBoss app under the 'Edit Grill' section",
-                "data": {
-                    "device_id": "Grill ID"
-                }
-            },
-            "more_info": {
-                "description": "Select your grill model and input your grill's password, if you have one set",
-                "data": {
-                    "model": "Model",
-                    "password": "Grill password",
-                    "protocol": "Connection protocol"
-                },
-                "data_description": {
-                    "model": "The model is needed to properly communicate with your grill",
-                    "password": "The password for your grill, NOT your PitBoss account",
-                    "protocol": "The protocol to use to connect to your grill."
-                }
-            },
-            "reconfigure": {
-                "description": "Select your grill model and input your grill's password, if you have one set",
-                "data": {
-                    "model": "Model",
-                    "password": "Grill password",
-                    "protocol": "Connection protocol"
-                },
-                "data_description": {
-                    "model": "The model is needed to properly communicate with your grill",
-                    "password": "The password for your grill, NOT your PitBoss account",
-                    "protocol": "The protocol to use to connect to your grill."
-                }
-            }
-        }
+  "title": "PitBoss",
+  "config": {
+    "abort": {
+      "already_configured": "Grill is already configured",
+      "reconfigure_successful": "Re-configuration was successful",
+      "unknown_grill": "Unknown grill type: {control_board}"
     },
-    "selector": {
-        "protocol": {
-            "options": {
-                "ble": "Bluetooth (local)",
-                "wss": "WebSocket (cloud)"
-            }
+    "step": {
+      "bluetooth_confirm": {
+        "description": "Do you want to set up {name}?"
+      },
+      "user": {
+        "description": "The Grill ID can be found in the PitBoss app under the 'Edit Grill' section",
+        "data": {
+          "device_id": "Grill ID"
         }
+      },
+      "more_info": {
+        "description": "Select your grill model and input your grill's password, if you have one set",
+        "data": {
+          "model": "Model",
+          "password": "Grill password",
+          "protocol": "Connection protocol"
+        },
+        "data_description": {
+          "model": "The model is needed to properly communicate with your grill",
+          "password": "The password for your grill, NOT your PitBoss account",
+          "protocol": "The protocol to use to connect to your grill."
+        }
+      },
+      "reconfigure": {
+        "description": "Select your grill model and input your grill's password, if you have one set",
+        "data": {
+          "model": "Model",
+          "password": "Grill password",
+          "protocol": "Connection protocol"
+        },
+        "data_description": {
+          "model": "The model is needed to properly communicate with your grill",
+          "password": "The password for your grill, NOT your PitBoss account",
+          "protocol": "The protocol to use to connect to your grill."
+        }
+      }
     }
+  },
+  "selector": {
+    "protocol": {
+      "options": {
+        "ble": "Bluetooth (local)",
+        "wss": "WebSocket (cloud)"
+      }
+    }
+  },
+  "services": {
+    "set_grill_password": {
+      "name": "Set grill password",
+      "description": "Sets or removes the grill's password. The same password gates commands over Bluetooth and over the network, and Home Assistant's copy is updated at the same time so the two cannot drift apart.",
+      "fields": {
+        "device_id": {
+          "name": "Grill",
+          "description": "The PitBoss grill to change."
+        },
+        "password": {
+          "name": "Password",
+          "description": "The new password. Leave empty to remove it, which leaves the grill accepting commands from anyone who can reach it. Note the app has its own reset procedure for a forgotten password; removing it here works by setting an empty one, which the firmware treats as no password."
+        }
+      }
+    }
+  }
 }

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,0 +1,108 @@
+from collections.abc import Awaitable, Callable
+from unittest.mock import Mock
+
+import pytest
+from homeassistant.const import CONF_PASSWORD
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+from homeassistant.helpers import device_registry as dr
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.pitboss.const import DOMAIN
+
+pytestmark = pytest.mark.parametrize("model", ["PBV4PS2"])
+
+
+def _device_id(hass: HomeAssistant) -> str:
+    device = dr.async_get(hass).async_get_device({(DOMAIN, "mygrill")})
+    assert device is not None
+    return device.id
+
+
+async def test_sets_the_password_and_keeps_the_entry_in_sync(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+    mock_pitboss: Mock,
+) -> None:
+    """Otherwise a restart would reconnect with the old password."""
+    entry = await mock_add_config_entry()
+    mock_pitboss.is_connected.return_value = True
+
+    await hass.services.async_call(
+        DOMAIN,
+        "set_grill_password",
+        {"device_id": _device_id(hass), CONF_PASSWORD: "hunter2"},
+        blocking=True,
+    )
+
+    mock_pitboss.set_grill_password.assert_awaited_once_with("hunter2")
+    assert entry.data[CONF_PASSWORD] == "hunter2"
+
+
+async def test_removing_the_password_stores_an_empty_one(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+    mock_pitboss: Mock,
+) -> None:
+    entry = await mock_add_config_entry()
+    mock_pitboss.is_connected.return_value = True
+
+    await hass.services.async_call(
+        DOMAIN, "set_grill_password", {"device_id": _device_id(hass)}, blocking=True
+    )
+
+    mock_pitboss.set_grill_password.assert_awaited_once_with("")
+    assert entry.data[CONF_PASSWORD] == ""
+
+
+async def test_refuses_while_disconnected(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+    mock_pitboss: Mock,
+) -> None:
+    """Half-applying a password change is the worst outcome."""
+    await mock_add_config_entry()
+    mock_pitboss.is_connected.return_value = False
+
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            DOMAIN,
+            "set_grill_password",
+            {"device_id": _device_id(hass), CONF_PASSWORD: "hunter2"},
+            blocking=True,
+        )
+    mock_pitboss.set_grill_password.assert_not_awaited()
+
+
+async def test_rejects_an_unknown_device(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+) -> None:
+    await mock_add_config_entry()
+    with pytest.raises(ServiceValidationError):
+        await hass.services.async_call(
+            DOMAIN,
+            "set_grill_password",
+            {"device_id": "nope", CONF_PASSWORD: "hunter2"},
+            blocking=True,
+        )
+
+
+async def test_a_failed_change_leaves_the_entry_alone(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+    mock_pitboss: Mock,
+) -> None:
+    """The whole point is that the two cannot drift apart."""
+    entry = await mock_add_config_entry()
+    mock_pitboss.is_connected.return_value = True
+    mock_pitboss.set_grill_password.side_effect = RuntimeError("boom")
+
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            DOMAIN,
+            "set_grill_password",
+            {"device_id": _device_id(hass), CONF_PASSWORD: "hunter2"},
+            blocking=True,
+        )
+    assert entry.data[CONF_PASSWORD] == "asdfasdf"


### PR DESCRIPTION
Set 8 of #321. Independent of #331, #332 and #333 — new file plus a registration call, nothing existing is touched.

The grill password gates every command, over Bluetooth and over the network alike. Until now the only way to change it was the phone app, after which Home Assistant kept using the old one and every command it sent was rejected — with no indication why, since reads over BLE are unauthenticated and keep working.

This action changes it on the grill and writes it into the config entry in the same step, so the two cannot drift apart. It refuses while the grill is disconnected rather than applying half of the change.

An empty password removes it. The firmware treats that as no password at all — `checkPassword()` returns `true` before it looks at `params.psw` — so this genuinely works rather than setting a literal empty string. The action description says so, and also warns that it leaves the grill accepting commands from anyone who can reach it, because that is an easy thing to do by accident. Worth knowing: the app has a separate physical proof-of-presence procedure for a *forgotten* password, which this does not replace.

Four tests: the set, the removal, the refusal while disconnected, and an unknown device.