### PR TITLE
Update pytboss to 2026.8.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ mypy==2.3.0
 pip>=26.2
 pyserial-asyncio==0.6
 pyserial==3.5
-pytboss==2026.8.1
+pytboss==2026.8.2
 pytest_homeassistant_custom_component==0.13.348
 ruff==0.16.0
 serialx==1.8.2


### PR DESCRIPTION
Carries [pytboss#504](https://github.com/dknowles2/pytboss/pull/504) (grills.json field trim) and [pytboss#507](https://github.com/dknowles2/pytboss/pull/507) (the REVIEW.md boundary doc).

## Breaking change upstream, not here

The trim removes `Command.name` as a public dataclass attribute. This integration is not exposed to it — commands are only ever reached through `ControlBoard.commands`, which is keyed by `slug`.

Verified against the released wheel rather than assuming:

```
installed pytboss 2026.8.2
models: 137
  PBL2: ['PB1150DX', 'PB850DX']
  PBL3: ['PB1020DX', 'PB1150DX', 'PB850DX', 'PBV4DX']
  LBL:  ['LG0800BL', 'LG1000BL', 'LG1200BL', 'LG300BL', 'LGV4BL']
  LFS:  ['LG1200FL', 'LG1200FP', 'LG800FL', 'LG800FP']
commands reachable: 1358
has_mpc is bool: True
```

The four boards the config flow tests against resolve to the same model sets as under 2026.8.1.

## Docs

`docs/SUPPORTED_GRILLS.md` is unchanged under 2026.8.2 — the trim dropped fields `scripts/generate_grill_docs.py` does not read, and no models were added or removed. Regenerating produces a byte-identical file, so `update-grill-docs.yml` will run on merge and exit at "No changes to commit". That is the expected outcome, not a failure.

Nothing is hand-edited here; the doc is left to the workflow either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)