### PR TITLE
Add review skills adapted from Home Assistant Core

### DIFF
--- a/.claude/skills/ha-pitboss-review/SKILL.md
+++ b/.claude/skills/ha-pitboss-review/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: ha-pitboss-review
+description: Reviews changes to the ha-pitboss Home Assistant integration. Use when reviewing a pull request, a branch, or uncommitted changes in this repository. Covers the boundary with the pytboss library, Home Assistant entity conventions, and the verification traps specific to this repo.
+---
+
+# Review ha-pitboss changes
+
+Adapted from Home Assistant Core's `ha-review` and `ha-integration-knowledge`
+skills (Apache-2.0). Modified for a HACS custom component: the quality-scale
+machinery and core file paths do not apply here, and the repository-specific
+sections are new.
+
+## Scope
+
+Review the branch's changes plus any uncommitted ones against the base. The
+base branch here is `main`, not `dev`:
+
+```sh
+git diff "$(git merge-base origin/main HEAD)"
+```
+
+For a pull request, get context with `gh pr view` and `gh pr diff` first.
+
+**Review only. Do not make changes, and do not post to GitHub — report in the
+console.** Do not spawn subagents; this repository is small enough to review
+directly.
+
+## 1. The boundary with pytboss — check this first
+
+This integration is a thin shell over
+[pytboss](https://github.com/dknowles2/pytboss). Home Assistant Core states the
+rule directly, and it is the one this repo has broken twice:
+
+> Integrations should be thin wrappers. Protocol parsing, device state
+> machines, or other domain logic belong in a separate PyPI library, not in the
+> integration itself.
+
+> Integrations should not implement fixes or workarounds for limitations in
+> libraries. Instead, the library should be updated to fix the issue.
+
+Concretely, **flag any change that remaps, aliases, or rewrites a control
+board.** `control_board` comes from the device ID prefix and is a fact about
+the hardware:
+
+```python
+control_board = self._device_id.split("-")[0]
+```
+
+Both past violations looked like one-line config-flow fixes that made a model
+selectable, and both produced frames read at the wrong offsets afterwards —
+`PBL2` grills borrowing `PBL3`'s definitions were converted to celsius twice
+(225°F shown as 107), and the proposed `LBL`→`PBL` alias would have read frames
+three bytes short. If a model cannot be added, the fix belongs upstream.
+
+See [REVIEW.md](../../../REVIEW.md) for the full symptom-to-repo table. The
+short version: anything that would still be wrong with no Home Assistant in the
+picture belongs in pytboss.
+
+## 2. Home Assistant conventions
+
+- Polling intervals are not user-configurable. Reject `scan_interval`,
+  `update_interval`, or polling-frequency options in config flows.
+- Do not let users set the config entry name in a config flow.
+- `async_added_to_hass()` and `async_will_remove_from_hass()` must be
+  symmetrical — anything subscribed in one is unsubscribed in the other.
+- Do not redeclare attributes, properties, or methods the entity base class
+  already provides, and do not guard against the base class changing.
+- Where Home Assistant's schema validation guarantees a key, index it directly
+  (`data["key"]`) rather than `.get("key")`, so a bad assumption fails loudly.
+- Avoid defensive checks for values Home Assistant already validates; add
+  guards only where a value bypasses validation or is transformed unsafely.
+- Tests should not reach into the integration's internals. Drive it through
+  Home Assistant's own interfaces.
+
+## 3. Verification traps in this repo
+
+These have each produced a wrong review conclusion before.
+
+- **Run `mypy .`, not `mypy custom_components/pitboss`.** CI checks the whole
+  tree, and errors in `tests/` are missed otherwise.
+- **A wholesale test failure is usually environmental.** If every test in a
+  file fails on `bluetooth_adapters` — including ones the change does not touch
+  — `homeassistant.setup` cannot start the `bluetooth` component locally. That
+  is not the change. Say the suite could not be run rather than implying it
+  passed.
+- **Check assertions are not vacuous.** A test asserting only that *some*
+  models came back passes whether or not the behaviour it names still holds;
+  that is how the `PBL2` workaround survived. Confirm against pytboss directly:
+
+  ```sh
+  python -c "from pytboss import grills; print(sorted(g.name for g in grills.get_grills('PBL2')))"
+  ```
+
+- **`docs/SUPPORTED_GRILLS.md` is generated.** It should not appear in a
+  hand-authored diff; `update-grill-docs.yml` regenerates it when the
+  `pytboss==` pin changes. A version bump belongs in its own PR.
+
+## 4. Also review for
+
+Code quality and consistency, bugs, performance, security, test coverage, and
+whether user-facing changes need documentation.
+
+## Output format
+
+List specific comments per file and line, then an overall assessment. Do not
+list what is already fine.
+
+```
+Overall assessment: request changes.
+- [CRITICAL] config_flow.py:88 - Remaps PBL2 to PBL3; belongs in pytboss
+- [PROBLEM] coordinator.py:41 - Subscription never torn down
+- [SUGGESTION] test_sensor.py:20 - Assertion passes even if the entity is absent
+```

--- a/.claude/skills/pr-comment-audit/SKILL.md
+++ b/.claude/skills/pr-comment-audit/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: pr-comment-audit
+description: Audits the review comment threads on a GitHub pull request, flagging unaddressed comments and requests for clarification. Use when checking whether PR feedback has been handled, either standalone or as part of a full review.
+---
+
+# Audit PR review comments
+
+Vendored from Home Assistant Core's `ha-pr-comment-audit` skill (Apache-2.0),
+with minor wording changes. The original carries no Home Assistant specifics.
+
+## Instructions
+
+- Resolve the PR context first. If no PR number is given, use `gh pr view` to
+  identify the current branch's PR.
+- Fetch the review comment threads (e.g. `gh api` for review threads and
+  comments).
+- Flag comments that have not been addressed. If the author replied but did not
+  implement the suggestion, still flag it and summarise the reply.
+- Flag comments where the author asked for clarification and got none.
+- Summarise the flagged comments, with a link for each. Omit comments that have
+  been addressed.
+
+## Important
+
+- Report in the CONSOLE only. Do not post anything to GitHub.

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ tts
 scenes.yaml
 scripts.yaml
 secrets.yaml
+# Claude Code scratch state; skills under .claude/skills are tracked.
+.claude/worktrees/
+.claude/settings.local.json


### PR DESCRIPTION
[Home Assistant Core](https://github.com/home-assistant/core/tree/dev/.claude/skills) publishes six agent skills. Two of them transfer to a HACS custom component; two actively do not.

| Skill | Verdict |
| --- | --- |
| `ha-pr-comment-audit` | Vendored — no Home Assistant specifics at all |
| `ha-integration-knowledge` | Partly adopted — roughly half is core-only |
| `ha-review` | Partly adopted — needs base branch and subagent changes |
| `ha-pr-reviewer` | Folded in; it is a thin wrapper over the other two |
| `ha-quality-scale-verify` | **Skipped** — quality scale is a core concept |
| `bump-dependency` | **Skipped** — built on `script.gen_requirements_all` |

A HACS component has no `quality_scale.yaml` and cannot declare a tier, and our bump path is Dependabot plus `sync-manifest-version.yml` and `update-grill-docs.yml`. Copying those two would send a reviewer hunting through `homeassistant/components/pitboss/` for files that should not exist — a document half-wrong on day one gets followed on the wrong half.

## What this adds

**`ha-pitboss-review`** combines the transferable guidance with what `REVIEW.md` already records. The find that made it worth doing is that Core states our boundary rule outright:

> Integrations should be thin wrappers. Protocol parsing, device state machines, or other domain logic belong in a separate PyPI library, not in the integration itself.

> Integrations should not implement fixes or workarounds for limitations in libraries. Instead, the library should be updated to fix the issue.

That is exactly the conclusion the `PBL2` and `LBL` incidents produced here, reached independently. Quoting it matters most for external contributors — #258 came from one — since it makes the rule Home Assistant's standard rather than the maintainer's preference.

The skill also carries the verification traps that have each caused a wrong conclusion before: run `mypy .` over the whole tree, a wholesale `bluetooth_adapters` failure is environmental rather than the change, and an assertion that only checks *some* models came back is how the `PBL2` workaround survived.

**`pr-comment-audit`** is vendored nearly verbatim.

Two deliberate departures from upstream `ha-review`: the base branch is `main` rather than `dev`, and it does not spawn up to 10 parallel subagents — this repo is small enough to review directly.

## Attribution

Home Assistant Core is Apache-2.0. Both files record their origin and that they were modified.

## .gitignore

`.claude` was untracked, so leftover worktrees sat exactly where the skills now go. Those and `settings.local.json` are ignored; `.claude/skills` is tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

