### PR TITLE
Pin pytboss 2026.8.2 in manifest.json too

### DIFF
--- a/custom_components/pitboss/manifest.json
+++ b/custom_components/pitboss/manifest.json
@@ -77,7 +77,7 @@
     "pytboss"
   ],
   "requirements": [
-    "pytboss==2026.8.1"
+    "pytboss==2026.8.2"
   ],
   "version": "0000.0.0"
 }


### PR DESCRIPTION
`manifest.json` still pins `pytboss==2026.8.1`. #336 bumped only `requirements.txt`, so CI has been testing against 2026.8.2 while Home Assistant installs 2026.8.1 at runtime. Every earlier bump — #316, #304, #147 — touched both files.

Two consequences:

- Users have been running the older library since #336 merged, without the `grills.json` work in 2026.8.2.
- It blocks #333, which reads `Grill.has_mpc`. That field does not exist in 2026.8.1, and `Grill` is a plain dataclass, so `coordinator.has_mpc` raises `AttributeError` during entity construction and the integration fails to set up. CI does not catch it because CI installs from `requirements.txt`.

Verified: `git show 2026.8.1:pytboss/grills.py` has no `has_mpc`; the `2026.8.2` tag does.

Worth adding the manifest pin to the version-bump checklist in `REVIEW.md`, which currently mentions only `requirements.txt` — happy to do that here or separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)