### PR TITLE
Document that the pytboss pin lives in two files

### DIFF
--- a/.claude/skills/ha-pitboss-review/SKILL.md
+++ b/.claude/skills/ha-pitboss-review/SKILL.md
@@ -95,6 +95,24 @@ These have each produced a wrong review conclusion before.
   hand-authored diff; `update-grill-docs.yml` regenerates it when the
   `pytboss==` pin changes. A version bump belongs in its own PR.
 
+- **The pytboss pin lives in two files, and CI only reads one.** Any change
+  using a library attribute added in a recent release needs both checked,
+  because `requirements.txt` is what CI installs and
+  `custom_components/pitboss/manifest.json` is what Home Assistant installs
+  for users:
+
+  ```sh
+  grep pytboss requirements.txt custom_components/pitboss/manifest.json
+  ```
+
+  If they disagree, a change relying on the newer one passes every check and
+  raises `AttributeError` at setup on real installs. Confirm the attribute
+  exists in the version the *manifest* pins, not the one CI resolves:
+
+  ```sh
+  git -C ../pytboss show <pinned-version>:pytboss/grills.py | grep <attribute>
+  ```
+
 ## 4. Also review for
 
 Code quality and consistency, bugs, performance, security, test coverage, and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,80 @@
+# Agent instructions for ha-pitboss
+
+`ha-pitboss` is a HACS custom component for Home Assistant that talks to
+PitBoss/Dansons grills. It is a thin shell over
+[pytboss](https://github.com/dknowles2/pytboss), which does all the protocol
+work.
+
+- [REVIEW.md](REVIEW.md) — where a change belongs, and the mistakes this repo
+  has actually made. Read it before changing anything that touches control
+  boards, grill models, or temperatures.
+- [CONTRIBUTING.md](CONTRIBUTING.md) — fork-and-PR mechanics.
+
+## Bumping the pytboss version
+
+**The pin lives in two files. Change both, in the same PR, every time.**
+
+```sh
+grep pytboss requirements.txt custom_components/pitboss/manifest.json
+```
+
+- `requirements.txt` — what CI installs.
+- `custom_components/pitboss/manifest.json`, in the `requirements` array —
+  what Home Assistant installs for users.
+
+Changing only one is the failure this section exists for, and it is silent:
+CI resolves the new release and goes green while every real install keeps the
+old one. Nothing surfaces until code uses something the older release does not
+have, and then it is an `AttributeError` during setup on users' machines, with
+a passing build behind it. This happened with 2026.8.2 — `requirements.txt`
+moved, `manifest.json` did not, and a PR was written against a `Grill.has_mpc`
+that shipped users did not have.
+
+Dependabot opens only the `requirements.txt` half, so its bump PRs need the
+manifest edited in before merging.
+
+Before relying on a pytboss attribute, confirm it exists in the version the
+**manifest** pins, not the one CI happens to resolve:
+
+```sh
+git -C ../pytboss show <pinned-version>:pytboss/grills.py | grep <attribute>
+```
+
+Keep a bump in its own PR, separate from any code that depends on it, and
+merge in order — a PR that reads a new attribute is blocked on the release
+*and* on the bump landing first, and neither CI nor GitHub can express that.
+Say so in the PR.
+
+## Gotchas
+
+- **Generated files — don't hand-edit**:
+  - `docs/SUPPORTED_GRILLS.md` is produced by `scripts/generate_grill_docs.py`
+    from whatever pytboss is installed. `.github/workflows/update-grill-docs.yml`
+    regenerates and commits it whenever the `pytboss==` pin in
+    `requirements.txt` changes, so it should never appear in a hand-authored
+    diff.
+  - `manifest.json`'s `version` is kept in step by `sync-manifest-version.yml`.
+    Its `requirements` array is not — that one is yours, see above.
+- **Never remap a control board here.** `control_board` comes from the device
+  ID prefix and is a fact about the hardware. This repo has made that mistake
+  twice, and both times it produced frames read at the wrong offsets. If a
+  model cannot be added, the fix is upstream in pytboss. REVIEW.md has both
+  cases in full.
+- **The test suite often cannot run locally.** `homeassistant.setup` needs the
+  `bluetooth` component, which fails to start in some environments; the symptom
+  is *every* test in a file failing on `bluetooth_adapters`, including ones the
+  change does not touch. That is environmental, and CI is then the real check —
+  say so rather than implying the tests were run.
+
+## Before committing
+
+Run the same checks CI runs, and make sure all three pass:
+
+```sh
+uv run pytest
+uv run ruff check .
+uv run mypy .
+```
+
+Run `mypy .`, not `mypy custom_components/pitboss` — CI checks the whole tree,
+and errors in `tests/` are easy to miss otherwise.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -127,10 +127,35 @@ survived as long as it did.
 A pytboss release is what carries protocol fixes into this repo:
 
 1. pytboss is released.
-2. Dependabot opens a `requirements.txt` bump, or bump it yourself in its own
-   PR, separate from any code that depends on it.
+2. Bump the pin in **both** files, in its own PR, separate from any code that
+   depends on it:
+
+   - `requirements.txt` — what CI installs.
+   - `custom_components/pitboss/manifest.json` — what Home Assistant installs
+     at runtime, in the `requirements` array.
+
 3. Merging that bump regenerates `docs/SUPPORTED_GRILLS.md` automatically.
+
+**Both pins, every time.** They are the whole reason a version bump can go
+wrong. Bumping only `requirements.txt` leaves CI testing one version while
+users run another, and the gap is invisible until code uses something the
+older release does not have — then every check passes and the integration
+raises `AttributeError` at setup on real installs. That happened with 2026.8.2:
+`requirements.txt` moved, `manifest.json` did not, and PR #333 was written
+against a `Grill.has_mpc` that shipped users did not have.
+
+Dependabot only opens the `requirements.txt` half, so its PRs need the
+manifest edited in before merging. When reviewing any bump, diff the two
+values against each other rather than reading either alone:
+
+```sh
+grep pytboss requirements.txt custom_components/pitboss/manifest.json
+```
 
 If a change here needs a pytboss version that isn't released yet, say so in the
 PR and merge in order — stacked PRs that depend on an unreleased library will
 fail CI in a way that looks like the change is broken.
+
+The same ordering applies to a merged-but-unreleased pytboss change: a PR that
+reads a new attribute is blocked on the release *and* on the bump landing
+first, and neither CI nor GitHub can express that. Say it in the PR.


### PR DESCRIPTION
Follow-up to #339, which fixed the pin itself. This documents why it was missable.

`REVIEW.md`'s version-bump steps named only `requirements.txt`, and the review skill had no check for the two pins disagreeing — so the 2026.8.2 bump touched one file and nothing caught it. The failure mode is the awkward one: every check passes, because CI installs from `requirements.txt` while Home Assistant installs from `manifest.json`, and the gap only surfaces as an `AttributeError` at setup on real installs once code uses something the older release lacks. #333 was written against a `Grill.has_mpc` that shipped users did not have.

- `REVIEW.md` — both files named in the bump steps, with the failure described and a one-line check. Also notes that Dependabot only opens the `requirements.txt` half, so its PRs need the manifest edited in before merging.
- `.claude/skills/ha-pitboss-review/SKILL.md` — a verification trap for it, including how to confirm an attribute exists in the version the *manifest* pins rather than the one CI resolves.

The pytboss side is [pytboss#522](https://github.com/dknowles2/pytboss/pull/522).

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)