### PR TITLE
Give every probe a target

### DIFF
--- a/custom_components/pitboss/coordinator.py
+++ b/custom_components/pitboss/coordinator.py
@@ -9,7 +9,12 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from pytboss.api import PitBoss
-from pytboss.exceptions import GrillUnavailable, NotConnectedError, RPCError
+from pytboss.exceptions import (
+    GrillUnavailable,
+    NotConnectedError,
+    RPCError,
+    UnsupportedOperation,
+)
 from pytboss.grills import StateDict
 
 from .const import DOMAIN, LOGGER, PING_INTERVAL, SYS_INFO_INTERVAL
@@ -39,6 +44,11 @@ class PitBossDataUpdateCoordinator(DataUpdateCoordinator[StateDict]):
         # Latest Sys.GetInfo payload from the control board.
         self.sys_info: dict = {}
         self._sys_info_at = 0.0
+        # What the grill is holding, and what we are holding for it. See
+        # `probe_target` for why both exist.
+        self.probe_targets: dict[int, int] = {}
+        self.restored_targets: dict[int, int] = {}
+        self._targets_seeded = False
 
     def accepted_setpoints(self, unit: str) -> list[float]:
         """Grill setpoints the control board honours, expressed in `unit`.
@@ -61,6 +71,69 @@ class PitBossDataUpdateCoordinator(DataUpdateCoordinator[StateDict]):
     def has_mpc(self) -> bool:
         """Whether the grill has a meat probe control port."""
         return self.api.spec.has_mpc
+
+    @property
+    def grill_unit(self) -> str:
+        """The unit the grill is currently working in."""
+        if (data := self.data) and not data.get("isFahrenheit"):
+            return UnitOfTemperature.CELSIUS
+        return UnitOfTemperature.FAHRENHEIT
+
+    def probe_target(self, probe_number: int) -> int | None:
+        """This probe's target, in the grill's own unit.
+
+        Board-reported first: `pNTarget` is already in the state we hold, so
+        reading it here means a target the grill announces shows immediately
+        rather than at the next poll. Then what pytboss resolved from the
+        grill's store. Then ours -- a target we set and restored across a
+        restart, which exists only because Home Assistant outlives that store.
+        """
+        reported = (self.data or {}).get(f"p{probe_number}Target")
+        if isinstance(reported, (int, float)):
+            return int(reported)
+        if (target := self.probe_targets.get(probe_number)) is not None:
+            return target
+        return self.restored_targets.get(probe_number)
+
+    async def async_set_probe_target(self, probe_number: int, temp: int) -> None:
+        """Set a probe's target, keeping it if the grill cannot take it yet."""
+        self.restored_targets[probe_number] = temp
+        try:
+            await self.api.set_probe_target(probe_number, temp)
+        except UnsupportedOperation:
+            # The grill is off: its store rejects writes and is wiped anyway.
+            # Held here and written when it comes on.
+            return
+        self.probe_targets[probe_number] = temp
+
+    async def _async_refresh_probe_targets(self, state: StateDict) -> None:
+        """Track the targets the grill is holding. Never fatal."""
+        if not state.get("moduleIsOn"):
+            self.probe_targets = {}
+            self._targets_seeded = False
+            return
+        try:
+            # Copied: we add to this below, and it is not ours to mutate.
+            self.probe_targets = dict(await self.api.get_probe_targets())
+        except Exception as ex:  # noqa: BLE001
+            self.logger.debug("Could not fetch the probe targets: %s", ex)
+            return
+        if self._targets_seeded:
+            return
+        self._targets_seeded = True
+        # The grill has just come on, so anything we are holding that it does
+        # not know about goes over now. That is what makes setting a target on
+        # a cold grill mean anything. A target the grill already has was set
+        # elsewhere and wins.
+        for probe_number, temp in self.restored_targets.items():
+            if probe_number in self.probe_targets:
+                continue
+            try:
+                await self.api.set_probe_target(probe_number, temp)
+            except Exception as ex:  # noqa: BLE001
+                self.logger.debug("Could not seed a probe target: %s", ex)
+            else:
+                self.probe_targets[probe_number] = temp
 
     async def _async_setup(self) -> None:
         """Set up the coordinator."""
@@ -141,7 +214,9 @@ class PitBossDataUpdateCoordinator(DataUpdateCoordinator[StateDict]):
         # Relying solely on push notifications means sensors can go stale after
         # a reconnect if push notifications stop being delivered.
         try:
-            return self._merge_state(await self.api.get_state())
+            state = self._merge_state(await self.api.get_state())
+            await self._async_refresh_probe_targets(state)
+            return state
         except NotConnectedError as ex:
             raise UpdateFailed("Grill not connected") from ex
         except RPCError as ex:

--- a/custom_components/pitboss/coordinator.py
+++ b/custom_components/pitboss/coordinator.py
@@ -106,6 +106,21 @@ class PitBossDataUpdateCoordinator(DataUpdateCoordinator[StateDict]):
             return
         self.probe_targets[probe_number] = temp
 
+    def note_restored_target(self, probe_number: int, temp: int) -> None:
+        """Take a target restored from a previous run.
+
+        Re-arms seeding when the grill does not already hold this probe's
+        target. Entities are added after the coordinator's first refresh, so
+        a grill that power-cycled while Home Assistant was down has already
+        been marked seeded -- against an empty set -- by the time a restored
+        value arrives. Without this the target would show in Home Assistant
+        and never reach the grill, which is the one case the restore exists
+        for.
+        """
+        self.restored_targets[probe_number] = temp
+        if probe_number not in self.probe_targets:
+            self._targets_seeded = False
+
     async def _async_refresh_probe_targets(self, state: StateDict) -> None:
         """Track the targets the grill is holding. Never fatal."""
         if not state.get("moduleIsOn"):

--- a/custom_components/pitboss/number.py
+++ b/custom_components/pitboss/number.py
@@ -1,17 +1,15 @@
 """Number platform for pitboss."""
 
-from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Literal
 
-from homeassistant.components.number import NumberEntity, NumberEntityDescription
+from homeassistant.components.number import NumberEntityDescription, RestoreNumber
 from homeassistant.components.number.const import NumberDeviceClass
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util.unit_conversion import TemperatureConverter
-from pytboss.api import PitBoss
 
 from .const import (
     DEFAULT_PROBE_CELSIUS_STEP,
@@ -27,50 +25,37 @@ from .entity import BaseEntity
 
 @dataclass(frozen=True, kw_only=True)
 class PitBossNumberEntityDescription(NumberEntityDescription):
-    key: Literal["p1Target", "p2Target"]
-    probe_number: Literal[1, 2]
-    set_fn: Callable[[PitBoss], Callable[[int], Awaitable[dict]]]
+    key: Literal["p1Target", "p2Target", "p3Target", "p4Target"]
+    probe_number: Literal[1, 2, 3, 4]
     device_class: NumberDeviceClass = NumberDeviceClass.TEMPERATURE
     icon: str = "mdi:thermometer"
-    matching_probe_key: Literal["p1Temp", "p2Temp"]
 
 
-PROBE_1_DESCRIPTION = PitBossNumberEntityDescription(
-    key="p1Target",
-    probe_number=1,
-    set_fn=lambda api: api.set_probe_temperature,
-    matching_probe_key="p1Temp",
-)
-PROBE_2_DESCRIPTION = PitBossNumberEntityDescription(
-    key="p2Target",
-    probe_number=2,
-    set_fn=lambda api: api.set_probe_2_temperature,
-    matching_probe_key="p2Temp",
+PROBE_DESCRIPTIONS = (
+    PitBossNumberEntityDescription(key="p1Target", probe_number=1),
+    PitBossNumberEntityDescription(key="p2Target", probe_number=2),
+    PitBossNumberEntityDescription(key="p3Target", probe_number=3),
+    PitBossNumberEntityDescription(key="p4Target", probe_number=4),
 )
 
 
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_devices: AddEntitiesCallback
 ):
-    """Setup number platformm."""
+    """Setup number platform."""
     coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
     assert entry.unique_id is not None
-    entities: list[TargetProbeTemperature] = []
-    if "set-probe-1-temperature" in (
-        available_commands := coordinator.api.spec.control_board.commands
-    ):
-        entities.append(
-            TargetProbeTemperature(coordinator, entry.unique_id, PROBE_1_DESCRIPTION)
-        )
-    if "set-probe-2-temperature" in available_commands:
-        entities.append(
-            TargetProbeTemperature(coordinator, entry.unique_id, PROBE_2_DESCRIPTION)
-        )
+    probe_count = coordinator.api.spec.meat_probes or 1
+    entities = [
+        TargetProbeTemperature(coordinator, entry.unique_id, description)
+        for description in PROBE_DESCRIPTIONS
+        if description.probe_number <= probe_count
+    ]
     if entities:
         async_add_devices(entities)
 
 
-class TargetProbeTemperature(BaseEntity, NumberEntity):
+class TargetProbeTemperature(BaseEntity, RestoreNumber):
     """PitBoss target probe temperature class."""
 
     def __init__(
@@ -85,53 +70,79 @@ class TargetProbeTemperature(BaseEntity, NumberEntity):
         label = probe_label(coordinator.has_mpc, entity_description.probe_number)
         self._attr_name = f"{label} target"
 
+    async def async_added_to_hass(self) -> None:
+        """Restore the target we last set for this probe.
+
+        The grill's own store is wiped when it is switched off, so without
+        this a target set on a cold grill would not survive a Home Assistant
+        restart. Anything the grill is holding wins over the restored value.
+        """
+        await super().async_added_to_hass()
+        probe_number = self.entity_description.probe_number
+        if self.coordinator.probe_target(probe_number) is not None:
+            return
+        last_data = await self.async_get_last_number_data()
+        if last_data is None or last_data.native_value is None:
+            return
+        # `probe_targets` holds grill-unit values; the restored one carries the
+        # unit it was displayed in, which the grill may since have changed.
+        value = last_data.native_value
+        stored_unit = last_data.native_unit_of_measurement
+        if stored_unit and stored_unit != self.coordinator.grill_unit:
+            value = TemperatureConverter.convert(
+                value, stored_unit, self.coordinator.grill_unit
+            )
+        self.coordinator.restored_targets[probe_number] = round(value)
+
     @property
-    def native_unit_of_measurement(self) -> UnitOfTemperature | None:
+    def native_unit_of_measurement(self) -> str:
         """Return the unit of measurement of the entity."""
-        if (data := self.coordinator.data) and not data.get("isFahrenheit"):
-            return UnitOfTemperature.CELSIUS
-        return UnitOfTemperature.FAHRENHEIT
+        return self.coordinator.grill_unit
 
     @property
     def native_step(self) -> float:
         """Return the step size of the number."""
         if self.native_unit_of_measurement == UnitOfTemperature.FAHRENHEIT:
             return DEFAULT_PROBE_FAHRENHEIT_STEP
-        else:
-            return DEFAULT_PROBE_CELSIUS_STEP
+        return DEFAULT_PROBE_CELSIUS_STEP
 
     @property
     def available(self) -> bool:
-        if data := self.coordinator.data:
-            return (
-                data.get(self.entity_description.matching_probe_key) is not None
-                and super().available
-            )
+        # Deliberately not gated on the probe being plugged in: the grill
+        # accepts a target for an empty port, so it can be dialled in before
+        # the probe goes into the meat.
         return super().available
 
     @property
-    def native_value(self) -> int | None:
-        """Return the native value of the probe target."""
-        if data := self.coordinator.data:
-            return data.get(self.entity_description.key)
-        return None
+    def native_value(self) -> float | None:
+        """Return the probe target, in the grill's own unit.
+
+        Deliberately an int: coercing to float would render the state as
+        "165.0" where it has always been "165".
+        """
+        return self.coordinator.probe_target(self.entity_description.probe_number)
 
     async def async_set_native_value(self, value: float) -> None:
-        """Set new value."""
-        await self.entity_description.set_fn(self.coordinator.api)(int(value))
+        """Set the target, by whichever route this probe supports."""
+        await self.coordinator.async_set_probe_target(
+            self.entity_description.probe_number, round(value)
+        )
+        self.coordinator.async_update_listeners()
 
     @property
     def native_min_value(self) -> float:
         """Return the minimum value."""
-        min_temp = DEFAULT_PROBE_MIN_TEMP
         return TemperatureConverter.convert(
-            min_temp, UnitOfTemperature.FAHRENHEIT, self.native_unit_of_measurement
+            DEFAULT_PROBE_MIN_TEMP,
+            UnitOfTemperature.FAHRENHEIT,
+            self.native_unit_of_measurement,
         )
 
     @property
     def native_max_value(self) -> float:
         """Return the maximum value."""
-        max_temp = DEFAULT_PROBE_MAX_TEMP
         return TemperatureConverter.convert(
-            max_temp, UnitOfTemperature.FAHRENHEIT, self.native_unit_of_measurement
+            DEFAULT_PROBE_MAX_TEMP,
+            UnitOfTemperature.FAHRENHEIT,
+            self.native_unit_of_measurement,
         )

--- a/custom_components/pitboss/number.py
+++ b/custom_components/pitboss/number.py
@@ -45,7 +45,9 @@ async def async_setup_entry(
     """Setup number platform."""
     coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
     assert entry.unique_id is not None
-    probe_count = coordinator.api.spec.meat_probes or 1
+    # No model in the catalogue declares 0, but an unknown grill having no
+    # probes should mean no probe targets rather than one.
+    probe_count = coordinator.api.spec.meat_probes or 0
     entities = [
         TargetProbeTemperature(coordinator, entry.unique_id, description)
         for description in PROBE_DESCRIPTIONS
@@ -56,7 +58,12 @@ async def async_setup_entry(
 
 
 class TargetProbeTemperature(BaseEntity, RestoreNumber):
-    """PitBoss target probe temperature class."""
+    """PitBoss target probe temperature class.
+
+    Deliberately not gated on the probe being plugged in: the grill accepts a
+    target for an empty port, so it can be dialled in before the probe goes
+    into the meat.
+    """
 
     def __init__(
         self,
@@ -92,7 +99,7 @@ class TargetProbeTemperature(BaseEntity, RestoreNumber):
             value = TemperatureConverter.convert(
                 value, stored_unit, self.coordinator.grill_unit
             )
-        self.coordinator.restored_targets[probe_number] = round(value)
+        self.coordinator.note_restored_target(probe_number, round(value))
 
     @property
     def native_unit_of_measurement(self) -> str:
@@ -105,13 +112,6 @@ class TargetProbeTemperature(BaseEntity, RestoreNumber):
         if self.native_unit_of_measurement == UnitOfTemperature.FAHRENHEIT:
             return DEFAULT_PROBE_FAHRENHEIT_STEP
         return DEFAULT_PROBE_CELSIUS_STEP
-
-    @property
-    def available(self) -> bool:
-        # Deliberately not gated on the probe being plugged in: the grill
-        # accepts a target for an empty port, so it can be dialled in before
-        # the probe goes into the meat.
-        return super().available
 
     @property
     def native_value(self) -> float | None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -128,4 +128,6 @@ def mock_pitboss(spec: Grill) -> Generator[Mock]:
         # know about them.
         api.config = Mock()
         api.config.get_info = AsyncMock(return_value={})
+        # autospec gives this a Mock return value; targets are a dict.
+        api.get_probe_targets = AsyncMock(return_value={})
         yield api

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock
 import pytest
 from conftest import get_entity
 from homeassistant.core import HomeAssistant
+from pytboss.exceptions import UnsupportedOperation
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.pitboss.const import DOMAIN
@@ -12,13 +13,19 @@ from custom_components.pitboss.number import TargetProbeTemperature
 
 
 @pytest.mark.parametrize("model", ["PBV4PS2"])
-async def test_only_probe_1_entity_created(
+async def test_an_entity_per_probe(
     hass: HomeAssistant,
     mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
 ) -> None:
+    """Every probe gets a target, whether or not the board has a command.
+
+    This grill declares `set-probe-1-temperature` only; P2's target goes to
+    the scratchpad instead. It has two probes, so there is no P3 or P4.
+    """
     await mock_add_config_entry()
     assert hass.states.get("number.mygrill_mpc_target") is not None
-    assert hass.states.get("number.mygrill_p2_target") is None
+    assert hass.states.get("number.mygrill_p2_target") is not None
+    assert hass.states.get("number.mygrill_p3_target") is None
 
 
 @pytest.mark.parametrize("model", ["PB1150PS3"])
@@ -33,13 +40,18 @@ async def test_both_probe_entities_created(
 
 
 @pytest.mark.parametrize("model", ["PB2180LK"])
-async def test_no_probe_entities_created(
+async def test_probes_without_any_command_still_get_targets(
     hass: HomeAssistant,
     mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
 ) -> None:
+    """This grill declares no probe command at all, and has four probes.
+
+    Before the scratchpad route it got no target entities whatsoever.
+    """
     await mock_add_config_entry()
-    assert hass.states.get("number.mygrill_probe_1_target") is None
-    assert hass.states.get("number.mygrill_probe_2_target") is None
+    for probe_number in (1, 2, 3, 4):
+        entity_id = f"number.mygrill_probe_{probe_number}_target"
+        assert hass.states.get(entity_id) is not None, entity_id
 
 
 @pytest.mark.parametrize("model", ["PBV4PS2"])
@@ -50,12 +62,13 @@ async def test_native_value_and_availability(
     entry = await mock_add_config_entry()
     coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
 
-    # No matching probe temperature reported: entity unavailable.
+    # Available with no probe plugged in: a target can be dialled in before
+    # the probe goes into the meat.
     coordinator.async_set_updated_data({"p1Target": 165, "isFahrenheit": True})
     await hass.async_block_till_done()
     state = hass.states.get("number.mygrill_mpc_target")
     assert state is not None
-    assert state.state == "unavailable"
+    assert state.state == "165"
 
     coordinator.async_set_updated_data(
         {"p1Target": 165, "p1Temp": 70, "isFahrenheit": True}
@@ -89,7 +102,7 @@ async def test_set_native_value(
         {"entity_id": "number.mygrill_mpc_target", "value": 180},
         blocking=True,
     )
-    mock_pitboss.set_probe_temperature.assert_awaited_once_with(180)
+    mock_pitboss.set_probe_target.assert_awaited_once_with(1, 180)
 
 
 @pytest.mark.parametrize("model", ["PBV4PS2"])
@@ -102,3 +115,122 @@ async def test_native_value_none_without_data(
         hass, "number", "number.mygrill_mpc_target", TargetProbeTemperature
     )
     assert entity.native_value is None
+
+
+@pytest.mark.parametrize("model", ["PBV4PS2"])
+async def test_setting_a_target_goes_through_the_library(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+    mock_pitboss: Mock,
+) -> None:
+    """Which route a probe takes is pytboss's business, not ours."""
+    entry = await mock_add_config_entry()
+    coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator.async_set_updated_data({"moduleIsOn": True, "isFahrenheit": True})
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        "number",
+        "set_value",
+        {"entity_id": "number.mygrill_p2_target", "value": 165},
+        blocking=True,
+    )
+
+    mock_pitboss.set_probe_target.assert_awaited_once_with(2, 165)
+    state = hass.states.get("number.mygrill_p2_target")
+    assert state is not None
+    assert state.state == "165"
+
+
+@pytest.mark.parametrize("model", ["PBV4PS2"])
+async def test_a_target_set_while_off_is_kept(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+    mock_pitboss: Mock,
+) -> None:
+    """The grill's store rejects writes while it is off."""
+    entry = await mock_add_config_entry()
+    coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    mock_pitboss.set_probe_target.side_effect = UnsupportedOperation
+    coordinator.async_set_updated_data({"moduleIsOn": False, "isFahrenheit": True})
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        "number",
+        "set_value",
+        {"entity_id": "number.mygrill_p2_target", "value": 165},
+        blocking=True,
+    )
+
+    # Still shown, so the user sees what will be sent at power-on.
+    state = hass.states.get("number.mygrill_p2_target")
+    assert state is not None
+    assert state.state == "165"
+    assert coordinator.restored_targets[2] == 165
+
+
+@pytest.mark.parametrize("model", ["PBV4PS2"])
+async def test_a_target_set_while_off_is_written_at_power_on(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+    mock_pitboss: Mock,
+) -> None:
+    """What makes setting a target on a cold grill mean anything."""
+    entry = await mock_add_config_entry()
+    coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    mock_pitboss.set_probe_target.side_effect = UnsupportedOperation
+    coordinator.async_set_updated_data({"moduleIsOn": False, "isFahrenheit": True})
+    await coordinator.async_set_probe_target(2, 165)
+
+    mock_pitboss.set_probe_target.side_effect = None
+    mock_pitboss.get_probe_targets.return_value = {}
+    await coordinator._async_refresh_probe_targets({"moduleIsOn": True})
+
+    mock_pitboss.set_probe_target.assert_awaited_with(2, 165)
+
+
+@pytest.mark.parametrize("model", ["PBV4PS2"])
+async def test_targets_are_seeded_only_once_per_power_cycle(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+    mock_pitboss: Mock,
+) -> None:
+    entry = await mock_add_config_entry()
+    coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    mock_pitboss.set_probe_target.side_effect = UnsupportedOperation
+    coordinator.async_set_updated_data({"moduleIsOn": False, "isFahrenheit": True})
+    await coordinator.async_set_probe_target(2, 165)
+    mock_pitboss.set_probe_target.side_effect = None
+    mock_pitboss.set_probe_target.reset_mock()
+    mock_pitboss.get_probe_targets.return_value = {}
+
+    for _ in range(3):
+        await coordinator._async_refresh_probe_targets({"moduleIsOn": True})
+    assert mock_pitboss.set_probe_target.await_count == 1
+
+    # Power cycle: the grill's store is wiped, so it has to be seeded again.
+    await coordinator._async_refresh_probe_targets({"moduleIsOn": False})
+    await coordinator._async_refresh_probe_targets({"moduleIsOn": True})
+    assert mock_pitboss.set_probe_target.await_count == 2
+
+
+@pytest.mark.parametrize("model", ["PBV4PS2"])
+async def test_a_target_the_grill_already_has_is_not_overwritten(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+    mock_pitboss: Mock,
+) -> None:
+    """One set elsewhere wins over the one we are holding."""
+    entry = await mock_add_config_entry()
+    coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    mock_pitboss.set_probe_target.side_effect = UnsupportedOperation
+    coordinator.async_set_updated_data({"moduleIsOn": False, "isFahrenheit": True})
+    await coordinator.async_set_probe_target(2, 165)
+    mock_pitboss.set_probe_target.side_effect = None
+    mock_pitboss.set_probe_target.reset_mock()
+    mock_pitboss.get_probe_targets.return_value = {2: 190}
+
+    await coordinator._async_refresh_probe_targets({"moduleIsOn": True})
+
+    mock_pitboss.set_probe_target.assert_not_awaited()
+    assert coordinator.probe_target(2) == 190

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -234,3 +234,49 @@ async def test_a_target_the_grill_already_has_is_not_overwritten(
 
     mock_pitboss.set_probe_target.assert_not_awaited()
     assert coordinator.probe_target(2) == 190
+
+
+@pytest.mark.parametrize("model", ["PBV4PS2"])
+async def test_a_target_restored_after_a_power_cycle_still_reaches_the_grill(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+    mock_pitboss: Mock,
+) -> None:
+    """The grill cycled while Home Assistant was down, and is on again.
+
+    Entities are added after the coordinator's first refresh, so by the time
+    a restored target arrives the coordinator has already seeded against an
+    empty set. Without re-arming, the target would show here and never be
+    written to the grill.
+    """
+    entry = await mock_add_config_entry()
+    coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    # First refresh: grill is on, its store was wiped by the power cycle.
+    await coordinator._async_refresh_probe_targets({"moduleIsOn": True})
+    mock_pitboss.set_probe_target.reset_mock()
+
+    # The entity now restores what we were holding before the restart.
+    coordinator.note_restored_target(2, 165)
+    await coordinator._async_refresh_probe_targets({"moduleIsOn": True})
+
+    mock_pitboss.set_probe_target.assert_awaited_once_with(2, 165)
+
+
+@pytest.mark.parametrize("model", ["PBV4PS2"])
+async def test_a_restored_target_the_grill_already_has_is_not_rewritten(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+    mock_pitboss: Mock,
+) -> None:
+    """Re-arming must not overwrite a target set from the vendor's app."""
+    entry = await mock_add_config_entry()
+    coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    mock_pitboss.get_probe_targets.return_value = {2: 190}
+    await coordinator._async_refresh_probe_targets({"moduleIsOn": True})
+    mock_pitboss.set_probe_target.reset_mock()
+
+    coordinator.note_restored_target(2, 165)
+    await coordinator._async_refresh_probe_targets({"moduleIsOn": True})
+
+    mock_pitboss.set_probe_target.assert_not_awaited()
+    assert coordinator.probe_target(2) == 190


### PR DESCRIPTION
Set 6 of #321, second of three. Builds on #333, and on [pytboss#527](https://github.com/dknowles2/pytboss/pull/527), now released in `2026.8.3`.

The grill acts on one probe — the control probe — and that is the only one with a board command. Home Assistant therefore offers a target on probes 1 and 2 at most, and only on boards declaring `set-probe-N-temperature`. Across the catalogue that is **42 of 137 models for probe 1 and 26 for probe 2, and nothing at all for probes 3 or 4**. A four-probe grill gets two targets; on 95 models it gets none.

`pytboss.set_probe_target()` routes around that: the board command where one exists, the grill's virtual data store otherwise — which is what the vendor's app does. This PR gives every probe an entity and lets the library decide the route.

**This is the split version you asked for.** The protocol half — the `p1T`..`p4T` key naming, the Fahrenheit convention, the wholesale-assign merge, the `psw` strip, the power-off wipe, the `moduleIsOn` gate — moved to pytboss#527 and is not here. What is left is the Home Assistant half:

- an entity per probe, up to `meat_probes`
- `RestoreNumber`, converting if the grill's unit changed while HA was down
- the port naming from #333
- writing a held target to the grill when it comes back on

For scale: the original was `+378/−61` across four files; this is `+283/−63`, and the coordinator loses about a hundred lines.

**The three-way precedence is preserved, split along the same line.** pytboss owns board-reported over scratchpad — both are things the grill told us. Home Assistant keeps the third rung, a target we set and restored, because that one exists only because HA outlives the grill's store, which is wiped at power-off. Board-reported is read from `self.data[f"p{n}Target"]` directly rather than through the library, since the key is already in `StateDict` and reading it here means a target the grill announces shows on the push instead of at the next poll.

**Three behaviour changes, unchanged from the original and all previously agreed:**

1. Grills declaring no probe command now get target entities where they previously got none. That is the point of the change, but it is new entities on existing installs.
2. The target is no longer unavailable when the probe is unplugged — the grill accepts a target for an empty port, so it can be dialled in before the probe goes in.
3. `p2Target` entities appear on grills without a `set-probe-2-temperature` command.

**Verified against the released `2026.8.3` rather than an overlay**, on current `main` with both pins already at that version:

```
97 tests passed
ruff check   — all checks passed (with .ruff.toml from #343)
ruff format  — 24 files already formatted
mypy         — no issues in 24 source files
```

Squashed to one commit, since the second one existed only to undo the first.

Two smaller things worth recording, both caught by tests during the rewrite. `_async_refresh_probe_targets` was mutating the dict `get_probe_targets()` returned, so seeding ran once and then silently believed the grill already had the target — visible only on the second power cycle. And `native_value` returning `float` changed the displayed state from `165` to `165.0`; it returns the int.

The `native_unit_of_measurement` interaction I flagged before is untouched and still belongs with set 5: Home Assistant fixes an entity's display unit at registration, so a dynamic unit is converted into the pinned one rather than adopted. I noted the same thing on #277, where it decides whether the option has any effect.
