### PR TITLE
Keep switches available when the grill is off

### DIFF
--- a/custom_components/pitboss/switch.py
+++ b/custom_components/pitboss/switch.py
@@ -47,9 +47,13 @@ class BaseSwitchEntity(BaseEntity, SwitchEntity):
 
     @property
     def available(self) -> bool:
-        """Return if the switch is available."""
-        if data := self.coordinator.data:
-            return bool(data.get("moduleIsOn", True)) and super().available
+        """Return if the switch is available.
+
+        Deliberately not gated on `moduleIsOn`. For the power switch that
+        gate was self-referential -- it hid the entity on exactly the state
+        the entity exists to report -- so it could never show `off`, and an
+        automation waiting for the grill to go off never saw it happen.
+        """
         return super().available
 
 

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -50,14 +50,15 @@ async def test_is_on_and_availability(
 
     coordinator.async_set_updated_data({"moduleIsOn": False, "primeState": False})
     await hass.async_block_till_done()
-    # All switches are unavailable when the module (grill) is off, since
-    # availability is gated on the shared "moduleIsOn" key.
+    # Switches stay available and report `off` when the grill is off, so an
+    # automation can trigger on the transition rather than on the entity
+    # disappearing.
     power_state = hass.states.get("switch.mygrill_module_power")
     prime_state = hass.states.get("switch.mygrill_prime")
     assert power_state is not None
     assert prime_state is not None
-    assert prime_state.state == "unavailable"
-    assert power_state.state == "unavailable"
+    assert power_state.state == "off"
+    assert prime_state.state == "off"
 
 
 @pytest.mark.parametrize("model", ["PBV4PS2"])
@@ -134,3 +135,46 @@ async def test_is_on_none_without_data(
     await mock_add_config_entry()
     entity = get_entity(hass, "switch", "switch.mygrill_module_power", PowerSwitch)
     assert entity.is_on is None
+
+
+@pytest.mark.parametrize("model", ["PBV4PS2"])
+async def test_the_power_switch_can_report_off(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+) -> None:
+    """It gates on the key it reports, so the old gate hid it to say `off`."""
+    entry = await mock_add_config_entry()
+    coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+
+    coordinator.async_set_updated_data({"moduleIsOn": True})
+    await hass.async_block_till_done()
+    state = hass.states.get("switch.mygrill_module_power")
+    assert state is not None
+    assert state.state == "on"
+
+    coordinator.async_set_updated_data({"moduleIsOn": False})
+    await hass.async_block_till_done()
+    state = hass.states.get("switch.mygrill_module_power")
+    assert state is not None
+    assert state.state == "off"
+
+
+@pytest.mark.parametrize("model", ["PBV4PS2"])
+async def test_switches_still_go_unavailable_when_disconnected(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+    mock_pitboss: Mock,
+) -> None:
+    """Dropping the `moduleIsOn` gate must not drop the connection one."""
+    entry = await mock_add_config_entry()
+    coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator.async_set_updated_data({"moduleIsOn": True})
+    await hass.async_block_till_done()
+
+    mock_pitboss.is_connected.return_value = False
+    coordinator.async_set_updated_data({"moduleIsOn": True})
+    await hass.async_block_till_done()
+
+    state = hass.states.get("switch.mygrill_module_power")
+    assert state is not None
+    assert state.state == "unavailable"


### PR DESCRIPTION
Set 8 of #321, and the last piece of it — the other half of the pair, dropping the unplugged-probe gate on target numbers, travelled in #341.

Switch availability is gated on `moduleIsOn`, so both switches disappear when the grill is off. This drops that gate.

**For the power switch the gate is self-referential rather than a policy choice.** Its `entity_description.key` *is* `moduleIsOn`, so it hides the entity on exactly the state the entity exists to report. It can never show `off` — it goes `unavailable` instead, and an automation waiting for the grill to go off never sees the transition, because `unavailable` is not a state you can trigger on the way you can trigger on `off`.

There is a test for that specifically: the switch reads `on`, then `off`, across a `moduleIsOn` change.

**The primer is the weaker half, and I would rather say so.** Priming a grill that is off does nothing, so `unavailable` is defensible there in a way it is not for the power switch. I have dropped it for both because that is what the roadmap item said and what I have been running, and because an entity that vanishes is a worse way to say "not now" than one that is present and off. **Happy to re-gate the primer alone** if you would rather — it is two lines and the power switch is the part that matters.

**What the gate protected is still protected.** `super().available` still gates on the connection, so a disconnected grill makes both switches unavailable exactly as before. There is a test for that too, since removing one gate and silently removing the other would be the easy mistake here.

`test_switch.py:53` encoded the old behaviour and now encodes the new — that is the assertion you flagged in the roadmap as being in the way, and it is updated rather than deleted.

Verified the new tests fail against the old gate rather than assuming they would: restoring it fails `test_the_power_switch_can_report_off` and `test_is_on_and_availability`, and nothing else.

92 tests, ruff, ruff format and mypy clean, on current `main` with `pytboss==2026.8.2`. No pytboss dependency — this is the only queued set that needs nothing from a release.
