### PR TITLE
Enforce ruff format in CI, and add a ruff config

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -45,6 +45,7 @@ jobs:
       - name: Run ruff
         run: |
           uv run ruff check --output-format=github .
+          uv run ruff format --check .
   mypy:
     runs-on: ubuntu-latest
     strategy:

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,19 @@
+# Ruff configuration.
+#
+# This repo keeps per-tool config in its own file -- see mypy.ini and
+# pytest.ini -- and has no pyproject.toml. Adding one only to hold these two
+# settings would also make uv treat the repo as a buildable project, which it
+# is not.
+#
+# `line-length` is what `ruff format` wraps to, so CI and a local run have to
+# agree on it. `target-version` was previously unset entirely: with no
+# pyproject.toml there was no `requires-python` for ruff to infer it from, so
+# version-dependent rules had nothing to work against. 3.14 matches
+# .python-version and Home Assistant's own floor.
+line-length    = 88
+target-version = "py314"
+
+# Deliberately no `[lint] select`: ruff 0.16's default rule set is much wider
+# than the `E4, E7, E9, F` the docs describe -- it includes BLE, B, S and
+# ASYNC among others, which is why `# noqa: BLE001` appears in this tree at
+# all. Naming a narrower set here would silently switch rules off.

--- a/scripts/sync_manifest_version.py
+++ b/scripts/sync_manifest_version.py
@@ -21,7 +21,9 @@ PACKAGE = "pytboss"
 
 
 def pinned_version(requirements_text: str, package: str) -> str:
-    match = re.search(rf"^{re.escape(package)}==([^\s]+)$", requirements_text, re.MULTILINE)
+    match = re.search(
+        rf"^{re.escape(package)}==([^\s]+)$", requirements_text, re.MULTILINE
+    )
     if not match:
         raise SystemExit(f"Could not find pinned '{package}==' line in {REQUIREMENTS}")
     return match.group(1)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,4 @@
 from collections.abc import Awaitable, Callable, Generator
-from typing import TypeVar
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -13,15 +12,13 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.pitboss.const import DOMAIN, PROTOCOL_WSS
 
-_EntityT = TypeVar("_EntityT", bound=Entity)
 
-
-def get_entity(
+def get_entity[EntityT: Entity](
     hass: HomeAssistant,
     platform_domain: str,
     entity_id: str,
-    entity_type: type[_EntityT],
-) -> _EntityT:
+    entity_type: type[EntityT],
+) -> EntityT:
     """Look up a live entity object bypassing the HA state machine.
 
     Useful for exercising code paths (like a falsy-data fallback) that HA's


### PR DESCRIPTION
Companion to [pytboss#531](https://github.com/dknowles2/pytboss/pull/531). Raised by @trailro on pytboss#524, who offered to add this and rightly declined to change CI uninvited.

`build-and-test.yml` runs `ruff check` but not `ruff format --check`. They are separate tools — linter and formatter — so formatting drift merges green. Unlike pytboss, this repo had already drifted: `scripts/sync_manifest_version.py` had an over-long `re.search(...)` the formatter wants wrapped. Fixed here.

## Why `.ruff.toml` and not `pyproject.toml`

This repo has no `pyproject.toml` and keeps per-tool config in its own file — `mypy.ini`, `pytest.ini`. Adding a `pyproject.toml` to hold two settings would also make `uv` treat the repo as a buildable project, which it is not; CI installs via `uv pip install -r requirements.txt`. `.ruff.toml` matches the existing convention and changes nothing else.

## The config surfaced a real finding

`target-version` was **unset entirely** — with no `pyproject.toml` there was no `requires-python` for ruff to infer it from, so version-dependent rules had nothing to work against. Setting it to `py314` (matching `.python-version` and Home Assistant's own floor) immediately flagged `UP047` in `tests/conftest.py`: `get_entity` used a `TypeVar` where PEP 695 type parameters are available.

```python
-_EntityT = TypeVar("_EntityT", bound=Entity)
-def get_entity(..., entity_type: type[_EntityT]) -> _EntityT:
+def get_entity[EntityT: Entity](..., entity_type: type[EntityT]) -> EntityT:
```

Its import block was re-sorted as a consequence of dropping the `TypeVar` import. Calling that out because it is a code change riding in a CI PR, not something I would want found later in a diff.

**No `[lint] select`, deliberately.** Ruff's documented default is `["E4", "E7", "E9", "F"]`, but ruff 0.16's actual default is far wider — `BLE`, `B`, `S`, `ASYNC` and more, which is why `# noqa: BLE001` appears in this tree at all. Writing the documented set down would silently switch rules off. Measured rather than taken from the docs.

Verified: `ruff check`, `ruff format --check` and `mypy` clean, 90 tests still collect. The suite itself cannot run locally here — every test fails on `bluetooth_adapters` because HA's `bluetooth` component will not start in my environment — so CI is the real check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)