### PR TITLE
Bump pytboss to 2026.8.3

### DIFF
--- a/custom_components/pitboss/manifest.json
+++ b/custom_components/pitboss/manifest.json
@@ -77,7 +77,7 @@
     "pytboss"
   ],
   "requirements": [
-    "pytboss==2026.8.2"
+    "pytboss==2026.8.3"
   ],
   "version": "0000.0.0"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ mypy==2.3.0
 pip>=26.2
 pyserial-asyncio==0.6
 pyserial==3.5
-pytboss==2026.8.2
+pytboss==2026.8.3
 pytest_homeassistant_custom_component==0.13.348
 ruff==0.16.0
 serialx==1.8.2


### PR DESCRIPTION
Bumps `pytboss` to [2026.8.3](https://github.com/dknowles2/pytboss/releases/tag/2026.8.3), the first release since 2026.8.2 and the one that unblocks everything queued behind it.

**Both pins moved**, per [AGENTS.md](AGENTS.md#bumping-the-pytboss-version):

```
requirements.txt:9                          pytboss==2026.8.3   # what CI installs
custom_components/pitboss/manifest.json:80  pytboss==2026.8.3   # what HA installs for users
```

Moving only one is the silent failure that section exists for, and it happened on the 2026.8.2 bump: CI resolved the new release and went green while every real install kept the old one.

## What this actually changes for users

Two of the ~30 upstream PRs are user-visible here rather than internal:

* **`celsius_temp_increment` is carried again.** PBV30DS and PBV30DX declare a Celsius setpoint list (`40..150` by 5) that is *not* the one derived from their Fahrenheit list (`37..148`, irregular). Until this release pytboss dropped the declared list, so those two models were being offered setpoints their boards do not accept. Verified against the installed release:

  ```
  PBV30DS celsius_temp_increments: [40, 45, 50, ... 145, 150]
  ```

* **Temperature commands now carry the grill's unit flag** ([pytboss#541](https://github.com/dknowles2/pytboss/pull/541)). On nine reachable boards the MCU always speaks Fahrenheit and the vendor's routine only converts when told the panel is in Celsius — so a Celsius grill asked for 100 °C was being set to 100 °F. This is a wire-format change, not an API change: `set_grill_temperature(temp)` has the same signature.

  **Worth flagging for anyone reviewing this:** neither repo's tests can show that fix working. `PBV4PS2`, the model this repo's fixtures are built on, is a `PBL` board — one of the eight whose routines take a single parameter and ignore the flag. Green tests here are not evidence about it in either direction. It wants confirming on a real Celsius-mode grill.

## Checks

`PitBoss` still carries all fourteen methods this integration calls, with unchanged signatures on the ones it passes arguments to — verified against the installed 2026.8.3 rather than against a checkout:

```
missing methods: none
set_grill_temperature(self, temp: int) -> dict
set_grill_password(self, new_password: str) -> None
subscribe_state(self, callback: Callable[[StateDict], Awaitable[None] | None])
get_state(self) -> StateDict
ping(self, timeout: float | None = None) -> dict
137 models
```

**The test suite cannot run locally** — `homeassistant.setup` fails on `bluetooth_adapters` in this environment, so every test in a file fails regardless of the change. CI is the real check here; I have not run the suite and am not implying otherwise.

`docs/SUPPORTED_GRILLS.md` is deliberately untouched: `update-grill-docs.yml` regenerates and commits it whenever the `requirements.txt` pin changes, so expect a follow-up commit on this branch rather than a hand-authored diff.

## After this lands

[#341](https://github.com/dknowles2/ha-pitboss/pull/341) unblocks — @trailro has the thin rewrite ready on their fork and has been holding it back specifically because it would go red against the pinned 2026.8.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
