### PR TITLE
Add a button platform: restart the controller, request fast updates

### DIFF
--- a/custom_components/pitboss/__init__.py
+++ b/custom_components/pitboss/__init__.py
@@ -39,6 +39,7 @@ from .services import async_register_services
 
 PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,
+    Platform.BUTTON,
     Platform.CLIMATE,
     Platform.LIGHT,
     Platform.NUMBER,

--- a/custom_components/pitboss/button.py
+++ b/custom_components/pitboss/button.py
@@ -1,0 +1,81 @@
+"""Button platform for pitboss."""
+
+from __future__ import annotations
+
+from homeassistant.components.button import ButtonDeviceClass, ButtonEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_PROTOCOL, EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DEFAULT_PROTOCOL, DOMAIN, PROTOCOL_WSS
+from .coordinator import PitBossDataUpdateCoordinator
+from .entity import BaseEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+):
+    """Setup button platform."""
+    coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    assert entry.unique_id is not None
+    entities: list[ButtonEntity] = [
+        RestartControllerButton(coordinator, entry.unique_id)
+    ]
+    # The fast-updates request accelerates the grill's push to the Dansons
+    # relay and nothing else, so it would be a decorative button on any other
+    # protocol.
+    if entry.data.get(CONF_PROTOCOL, DEFAULT_PROTOCOL) == PROTOCOL_WSS:
+        entities.append(FastUpdatesButton(coordinator, entry.unique_id))
+    async_add_entities(entities)
+
+
+class RestartControllerButton(BaseEntity, ButtonEntity):
+    """Reboots the grill's WiFi module.
+
+    The standard remedy when the module wedges. It drops the connection for a
+    short while; the grill itself keeps running.
+    """
+
+    _attr_device_class = ButtonDeviceClass.RESTART
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(
+        self,
+        coordinator: PitBossDataUpdateCoordinator,
+        entry_unique_id: str,
+    ) -> None:
+        super().__init__(coordinator, entry_unique_id)
+        self._attr_unique_id = f"restart_{entry_unique_id}"
+        self._attr_name = "Restart controller"
+
+    async def async_press(self) -> None:
+        """Reboot the module."""
+        await self.coordinator.api.reboot()
+
+
+class FastUpdatesButton(BaseEntity, ButtonEntity):
+    """Asks the grill to push status to the cloud every 5s for 5 minutes.
+
+    Despite the underlying RPC being named `PB.WiFiAwakeWDT` this does not
+    keep the WiFi module awake: it arms a five-minute countdown that makes the
+    firmware reschedule its push timer to the fast interval instead of the
+    slow one. It does nothing at all unless the grill is on, and nothing on
+    any transport but the cloud one.
+    """
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_icon = "mdi:speedometer"
+
+    def __init__(
+        self,
+        coordinator: PitBossDataUpdateCoordinator,
+        entry_unique_id: str,
+    ) -> None:
+        super().__init__(coordinator, entry_unique_id)
+        self._attr_unique_id = f"fast_updates_{entry_unique_id}"
+        self._attr_name = "Request fast updates"
+
+    async def async_press(self) -> None:
+        """Request the faster push cadence."""
+        await self.coordinator.api.request_fast_updates()

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -1,0 +1,80 @@
+from collections.abc import Awaitable, Callable
+from unittest.mock import Mock, patch
+
+import pytest
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import CONF_DEVICE_ID, CONF_MODEL, CONF_PASSWORD, CONF_PROTOCOL
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.pitboss.const import DOMAIN, PROTOCOL_BLE
+
+pytestmark = pytest.mark.parametrize("model", ["PBV4PS2"])
+
+
+async def test_restart_button(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+    mock_pitboss: Mock,
+) -> None:
+    entry = await mock_add_config_entry()
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator.async_set_updated_data({"moduleIsOn": True})
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        "button",
+        "press",
+        {"entity_id": "button.mygrill_restart_controller"},
+        blocking=True,
+    )
+
+    mock_pitboss.reboot.assert_awaited_once_with()
+
+
+async def test_fast_updates_button(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+    mock_pitboss: Mock,
+) -> None:
+    entry = await mock_add_config_entry()
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator.async_set_updated_data({"moduleIsOn": True})
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        "button",
+        "press",
+        {"entity_id": "button.mygrill_request_fast_updates"},
+        blocking=True,
+    )
+
+    mock_pitboss.request_fast_updates.assert_awaited_once_with()
+
+
+async def test_no_fast_updates_button_over_bluetooth(
+    hass: HomeAssistant, mock_pitboss: Mock
+) -> None:
+    """It only speeds up the push to the relay, so elsewhere it is a no-op."""
+    with patch("pytboss.ble.BleConnection", autospec=True) as mock_ble_cls:
+        mock_ble_cls.return_value.is_connected.return_value = True
+        mock_pitboss.get_state.return_value = {}
+
+        entry = MockConfigEntry(
+            title="title",
+            domain=DOMAIN,
+            data={
+                CONF_DEVICE_ID: "mygrill",
+                CONF_MODEL: "PBV4PS2",
+                CONF_PASSWORD: "asdfasdf",
+                CONF_PROTOCOL: PROTOCOL_BLE,
+            },
+            unique_id="mygrillid",
+        )
+        entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.LOADED
+    assert hass.states.get("button.mygrill_restart_controller") is not None
+    assert hass.states.get("button.mygrill_request_fast_updates") is None


### PR DESCRIPTION
Set 5 of #321, first of two. Needs `pytboss 2026.8.3`, which `main` already pins.

Adds a `button` platform with two entities, both wrapping RPCs that have public wrappers as of [pytboss#530](https://github.com/dknowles2/pytboss/pull/530).

**Restart controller** — `api.reboot()`. The standard remedy when the WiFi module wedges: it drops the connection briefly, the grill keeps running. Over four weeks on Bluetooth mine lost the grill repeatedly, once for 32 minutes, caused by the module rebooting itself; being able to do that deliberately is the point.

**Request fast updates** — `api.request_fast_updates()`, and this one is deliberately not created on every entry.

Despite the RPC's name (`PB.WiFiAwakeWDT`) it does not keep the module awake. It arms a five-minute countdown that makes the firmware reschedule its status-push timer to `wsFastInterval` instead of `wsSlowInterval` — 5 seconds instead of 60. The push it accelerates is `WS.send(wsConn, ...)`, so **it does nothing on Bluetooth or a local connection**, and nothing at all while the grill is off (`lastWasOn || moduleIsOn` guards the send).

So it is gated on `CONF_PROTOCOL == PROTOCOL_WSS`. I would rather not ship a button that is a no-op on the transport most people are using — and I say that as someone who ran exactly that button locally for weeks before reading the firmware carefully enough to notice.

There is a test for the gate, and I verified it fails without it: removing the condition makes `test_no_fast_updates_button_over_bluetooth` fail and nothing else. It follows the BLE setup pattern already in `test_init.py` rather than inventing a fixture for it.

**On `Sys.Reboot`, inherited from #530 and worth repeating here:** it is a Mongoose OS core RPC rather than one the grill's app registers, so its availability rests on that core service being enabled. `Sys.GetInfo` working on my grill is a positive signal but not proof for `Sys.Reboot` specifically, and I have not pressed this button on a grill mid-cook to find out. If it turns out to be absent on some board, the failure is an `RPCError` from a button press rather than anything structural.

95 tests, ruff, `ruff format --check` and mypy clean on current `main`.

The second half of set 5 — a select for the unit the grill itself works in — is next, and is independent of this.
