### PR TITLE
Add a select for the unit the grill itself works in

### DIFF
--- a/custom_components/pitboss/__init__.py
+++ b/custom_components/pitboss/__init__.py
@@ -43,6 +43,7 @@ PLATFORMS: list[Platform] = [
     Platform.CLIMATE,
     Platform.LIGHT,
     Platform.NUMBER,
+    Platform.SELECT,
     Platform.SENSOR,
     Platform.SWITCH,
 ]

--- a/custom_components/pitboss/select.py
+++ b/custom_components/pitboss/select.py
@@ -1,0 +1,99 @@
+"""Select platform for pitboss."""
+
+from __future__ import annotations
+
+from homeassistant.components.select import SelectEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import UnitOfTemperature
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.event import async_call_later
+
+from .const import DOMAIN
+from .coordinator import PitBossDataUpdateCoordinator
+from .entity import BaseEntity
+
+# The MCU is polled every couple of seconds; give it time to report back.
+MCU_SETTLE_SECONDS = 6
+
+UNIT_CELSIUS = UnitOfTemperature.CELSIUS
+UNIT_FAHRENHEIT = UnitOfTemperature.FAHRENHEIT
+
+# Board command slugs that switch the unit the grill itself works in.
+UNIT_COMMANDS = {
+    UNIT_CELSIUS: "set-celsius",
+    UNIT_FAHRENHEIT: "set-fahrenheit",
+}
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+):
+    """Setup select platform."""
+    coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    assert entry.unique_id is not None
+    commands = coordinator.api.spec.control_board.commands
+    if all(slug in commands for slug in UNIT_COMMANDS.values()):
+        async_add_entities([GrillTemperatureUnitSelect(coordinator, entry.unique_id)])
+
+
+class GrillTemperatureUnitSelect(BaseEntity, SelectEntity):
+    """The temperature unit the grill itself displays and reports in.
+
+    This changes a setting on the grill, not how Home Assistant presents
+    values -- every temperature the board reports follows it.
+    """
+
+    _attr_icon = "mdi:temperature-celsius"
+
+    def __init__(
+        self,
+        coordinator: PitBossDataUpdateCoordinator,
+        entry_unique_id: str,
+    ) -> None:
+        super().__init__(coordinator, entry_unique_id)
+        self._attr_unique_id = f"grill_temperature_unit_{entry_unique_id}"
+        self._attr_name = "Grill temperature unit"
+        # Set per instance rather than on the class: the base declares it as
+        # an instance variable, so a class-level list is both a mutable class
+        # attribute and a mypy override error.
+        self._attr_options = [UNIT_CELSIUS, UNIT_FAHRENHEIT]
+        self._pending_option: str | None = None
+
+    @property
+    def _reported_option(self) -> str | None:
+        if data := self.coordinator.data:
+            return UNIT_FAHRENHEIT if data.get("isFahrenheit") else UNIT_CELSIUS
+        return None
+
+    @property
+    def current_option(self) -> str | None:
+        # Show what we asked for until the grill confirms it: the board wipes
+        # its cached status the moment it forwards a command to the MCU, so
+        # the next poll still carries the old unit and the UI would appear to
+        # snap back.
+        return self._pending_option or self._reported_option
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        if self._pending_option and self._reported_option == self._pending_option:
+            self._pending_option = None
+        super()._handle_coordinator_update()
+
+    async def async_select_option(self, option: str) -> None:
+        """Switch the unit the grill works in."""
+        await self.coordinator.api.set_temperature_unit(
+            fahrenheit=option == UNIT_FAHRENHEIT
+        )
+        self._pending_option = option
+        self.async_write_ha_state()
+        # The MCU reports back within a couple of seconds; an immediate
+        # refresh would only read the cleared status. Tie the timer to the
+        # entity so unloading in the meantime cancels it instead of firing at
+        # a coordinator that is already gone.
+        self.async_on_remove(
+            async_call_later(self.hass, MCU_SETTLE_SECONDS, self._async_confirm)
+        )
+
+    async def _async_confirm(self, _now) -> None:
+        await self.coordinator.async_request_refresh()

--- a/custom_components/pitboss/select.py
+++ b/custom_components/pitboss/select.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from homeassistant.components.select import SelectEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfTemperature
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_call_later
 
@@ -59,6 +59,21 @@ class GrillTemperatureUnitSelect(BaseEntity, SelectEntity):
         # attribute and a mypy override error.
         self._attr_options = [UNIT_CELSIUS, UNIT_FAHRENHEIT]
         self._pending_option: str | None = None
+        self._cancel_settle: CALLBACK_TYPE | None = None
+
+    async def async_added_to_hass(self) -> None:
+        """Register the one removal callback this entity needs."""
+        await super().async_added_to_hass()
+        # Registered once rather than per selection: `async_on_remove` only
+        # appends, so re-registering would grow the list for the life of the
+        # entity. This cancels whichever timer is current.
+        self.async_on_remove(self._cancel_pending_settle)
+
+    @callback
+    def _cancel_pending_settle(self) -> None:
+        if self._cancel_settle is not None:
+            self._cancel_settle()
+            self._cancel_settle = None
 
     @property
     def _reported_option(self) -> str | None:
@@ -88,12 +103,20 @@ class GrillTemperatureUnitSelect(BaseEntity, SelectEntity):
         self._pending_option = option
         self.async_write_ha_state()
         # The MCU reports back within a couple of seconds; an immediate
-        # refresh would only read the cleared status. Tie the timer to the
-        # entity so unloading in the meantime cancels it instead of firing at
-        # a coordinator that is already gone.
-        self.async_on_remove(
-            async_call_later(self.hass, MCU_SETTLE_SECONDS, self._async_confirm)
+        # refresh would only read the cleared status. A second selection
+        # inside the window replaces the timer rather than queueing another.
+        self._cancel_pending_settle()
+        self._cancel_settle = async_call_later(
+            self.hass, MCU_SETTLE_SECONDS, self._async_confirm
         )
 
     async def _async_confirm(self, _now) -> None:
+        self._cancel_settle = None
         await self.coordinator.async_request_refresh()
+        # One settle window is all the pending value is for. If the refresh
+        # confirmed the change, `_handle_coordinator_update` has already
+        # cleared it; if the grill did not take it, follow the grill rather
+        # than assert a value it will never report.
+        if self._pending_option is not None:
+            self._pending_option = None
+            self.async_write_ha_state()

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -1,0 +1,123 @@
+from collections.abc import Awaitable, Callable
+from datetime import timedelta
+from unittest.mock import Mock
+
+import pytest
+from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
+from pytest_homeassistant_custom_component.common import (
+    MockConfigEntry,
+    async_fire_time_changed,
+)
+
+from custom_components.pitboss.const import DOMAIN
+from custom_components.pitboss.select import MCU_SETTLE_SECONDS
+
+pytestmark = pytest.mark.parametrize("model", ["PBV4PS2"])
+
+
+async def test_reports_the_unit_the_grill_is_in(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+) -> None:
+    entry = await mock_add_config_entry()
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+
+    coordinator.async_set_updated_data({"isFahrenheit": True})
+    await hass.async_block_till_done()
+    state = hass.states.get("select.mygrill_grill_temperature_unit")
+    assert state is not None
+    assert state.state == "°F"
+
+    coordinator.async_set_updated_data({"isFahrenheit": False})
+    await hass.async_block_till_done()
+    state = hass.states.get("select.mygrill_grill_temperature_unit")
+    assert state is not None
+    assert state.state == "°C"
+
+
+async def test_selecting_switches_the_grill(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+    mock_pitboss: Mock,
+) -> None:
+    entry = await mock_add_config_entry()
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator.async_set_updated_data({"isFahrenheit": True})
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        "select",
+        "select_option",
+        {"entity_id": "select.mygrill_grill_temperature_unit", "option": "°C"},
+        blocking=True,
+    )
+
+    mock_pitboss.set_temperature_unit.assert_awaited_once_with(fahrenheit=False)
+
+
+async def test_the_choice_holds_until_the_grill_confirms(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+) -> None:
+    """The board clears its cached status when it forwards a command.
+
+    So the next poll still carries the old unit, and without holding the
+    pending choice the UI would appear to snap back.
+    """
+    entry = await mock_add_config_entry()
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator.async_set_updated_data({"isFahrenheit": True})
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        "select",
+        "select_option",
+        {"entity_id": "select.mygrill_grill_temperature_unit", "option": "°C"},
+        blocking=True,
+    )
+    state = hass.states.get("select.mygrill_grill_temperature_unit")
+    assert state is not None
+    assert state.state == "°C"
+
+    # A poll still reporting the old unit must not undo the choice.
+    coordinator.async_set_updated_data({"isFahrenheit": True})
+    await hass.async_block_till_done()
+    state = hass.states.get("select.mygrill_grill_temperature_unit")
+    assert state is not None
+    assert state.state == "°C"
+
+    # Once the grill agrees, the pending value is dropped and it follows again.
+    coordinator.async_set_updated_data({"isFahrenheit": False})
+    await hass.async_block_till_done()
+    coordinator.async_set_updated_data({"isFahrenheit": True})
+    await hass.async_block_till_done()
+    state = hass.states.get("select.mygrill_grill_temperature_unit")
+    assert state is not None
+    assert state.state == "°F"
+
+
+async def test_a_refresh_is_requested_after_the_mcu_settles(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+    mock_pitboss: Mock,
+) -> None:
+    entry = await mock_add_config_entry()
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator.async_set_updated_data({"isFahrenheit": True})
+    await hass.async_block_till_done()
+    mock_pitboss.get_state.reset_mock()
+
+    await hass.services.async_call(
+        "select",
+        "select_option",
+        {"entity_id": "select.mygrill_grill_temperature_unit", "option": "°C"},
+        blocking=True,
+    )
+    assert mock_pitboss.get_state.await_count == 0
+
+    async_fire_time_changed(
+        hass, dt_util.utcnow() + timedelta(seconds=MCU_SETTLE_SECONDS + 1)
+    )
+    await hass.async_block_till_done()
+    assert mock_pitboss.get_state.await_count >= 1

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 from unittest.mock import Mock
 
 import pytest
+from conftest import get_entity
 from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
 from pytest_homeassistant_custom_component.common import (
@@ -11,7 +12,10 @@ from pytest_homeassistant_custom_component.common import (
 )
 
 from custom_components.pitboss.const import DOMAIN
-from custom_components.pitboss.select import MCU_SETTLE_SECONDS
+from custom_components.pitboss.select import (
+    MCU_SETTLE_SECONDS,
+    GrillTemperatureUnitSelect,
+)
 
 pytestmark = pytest.mark.parametrize("model", ["PBV4PS2"])
 
@@ -121,3 +125,88 @@ async def test_a_refresh_is_requested_after_the_mcu_settles(
     )
     await hass.async_block_till_done()
     assert mock_pitboss.get_state.await_count >= 1
+
+
+async def test_the_choice_is_dropped_if_the_grill_never_takes_it(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+) -> None:
+    """One settle window is all the pending value is for.
+
+    A command the grill accepts but does not apply would otherwise leave the
+    entity asserting a unit the grill will never report, for its whole life.
+    """
+    entry = await mock_add_config_entry()
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator.async_set_updated_data({"isFahrenheit": True})
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        "select",
+        "select_option",
+        {"entity_id": "select.mygrill_grill_temperature_unit", "option": "°C"},
+        blocking=True,
+    )
+    state = hass.states.get("select.mygrill_grill_temperature_unit")
+    assert state is not None
+    assert state.state == "°C"
+
+    # The grill keeps reporting the old unit past the settle window.
+    async_fire_time_changed(
+        hass, dt_util.utcnow() + timedelta(seconds=MCU_SETTLE_SECONDS + 1)
+    )
+    await hass.async_block_till_done()
+    coordinator.async_set_updated_data({"isFahrenheit": True})
+    await hass.async_block_till_done()
+
+    state = hass.states.get("select.mygrill_grill_temperature_unit")
+    assert state is not None
+    assert state.state == "°F"
+
+
+async def test_selections_do_not_pile_up_timers(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+) -> None:
+    """Each selection replaces the settle timer rather than adding one.
+
+    `async_on_remove` only appends, so registering per selection would grow
+    the entity's removal list for its lifetime, and every window would fire
+    once per selection made inside it.
+    """
+    entry = await mock_add_config_entry()
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator.async_set_updated_data({"isFahrenheit": True})
+    await hass.async_block_till_done()
+    entity = get_entity(
+        hass,
+        "select",
+        "select.mygrill_grill_temperature_unit",
+        GrillTemperatureUnitSelect,
+    )
+    removals = len(entity._on_remove or ())
+    confirms = []
+    original = entity._async_confirm
+
+    async def counting_confirm(now):
+        confirms.append(now)
+        await original(now)
+
+    entity._async_confirm = counting_confirm  # type: ignore[method-assign]
+
+    for option in ("°C", "°F", "°C"):
+        await hass.services.async_call(
+            "select",
+            "select_option",
+            {"entity_id": "select.mygrill_grill_temperature_unit", "option": option},
+            blocking=True,
+        )
+
+    assert len(entity._on_remove or ()) == removals
+
+    async_fire_time_changed(
+        hass, dt_util.utcnow() + timedelta(seconds=MCU_SETTLE_SECONDS + 1)
+    )
+    await hass.async_block_till_done()
+
+    assert len(confirms) == 1


### PR DESCRIPTION
Set 5 of #321, second of two. Independent of #346. Needs `pytboss 2026.8.3`, which `main` already pins.

Every board declares `set-celsius` and `set-fahrenheit`, but until [pytboss#520](https://github.com/dknowles2/pytboss/pull/520) neither was reachable without a private call, so `isFahrenheit` was the one grill setting Home Assistant could observe and not change. This adds a select for it, via the new `api.set_temperature_unit()`.

**This changes a setting on the grill**, not how Home Assistant presents values — every temperature the board reports follows it, and the panel changes too. That is deliberately a different thing from the display override in #277, and I have said so in the entity docstring so the two are not confused when both exist.

Only created when the board declares both commands.

**The interesting part is the pending state, and it is not cosmetic.** The board clears its cached status (`sc_11`/`sc_12`) the moment it forwards a command to the MCU, so the next poll still carries the old unit. Without holding the chosen value the UI snaps back to the previous option a second after the user picks one, then flips again when the MCU catches up.

So the entity shows what was asked for until the grill confirms it, then drops the pending value and follows the grill again. There is a test for the whole sequence — pick, a stale poll that must not undo it, then confirmation — and I verified it fails without the pending value rather than assuming it would.

The settle timer is tied to the entity with `async_on_remove`, so unloading the entry mid-wait cancels it instead of firing at a coordinator that has gone away.

**One thing I deliberately did not do:** no optimistic conversion of other entities' values. When the grill switches to Celsius every temperature it reports changes unit, and Home Assistant pins an entity's displayed unit at registration — so those entities convert into the pinned unit rather than adopting the new one. That is the same interaction I flagged on #341 and #277, and it belongs wherever the display-unit question is settled, not here.

96 tests, ruff, `ruff format --check` and mypy clean on current `main`.
