### PR TITLE
Add a target-reached sensor for every probe

### DIFF
--- a/custom_components/pitboss/binary_sensor.py
+++ b/custom_components/pitboss/binary_sensor.py
@@ -123,6 +123,10 @@ async def async_setup_entry(
     for entity_description in ENTITY_DESCRIPTIONS:
         entities.append(BinarySensor(coordinator, entry.unique_id, entity_description))
     entities.append(ConnectivitySensor(coordinator, entry.unique_id))
+    for probe_number in range(1, (coordinator.api.spec.meat_probes or 0) + 1):
+        entities.append(
+            ProbeTargetReachedSensor(coordinator, entry.unique_id, probe_number)
+        )
     async_add_entities(entities)
 
 
@@ -180,3 +184,40 @@ class ConnectivitySensor(BaseEntity, BinarySensorEntity):
     @property
     def is_on(self) -> bool:
         return bool(self.coordinator.api) and self.coordinator.api.is_connected()
+
+
+class ProbeTargetReachedSensor(BaseEntity, BinarySensorEntity):
+    """Whether a probe has reached the target set for it.
+
+    The grill acts on the control probe only, so it raises nothing for the
+    rest. This gives every probe the same signal to automate on, comparing
+    the reported temperature against whatever target the probe has -- one the
+    board reports, one in its virtual data store, or one restored here.
+
+    Deliberately `off` rather than unknown when there is no probe or no
+    target: an automation triggering on off-to-on does not fire reliably out
+    of `unknown` or `unavailable`, and this entity exists to be triggered on.
+    """
+
+    _attr_icon = "mdi:thermometer-check"
+
+    def __init__(
+        self,
+        coordinator: PitBossDataUpdateCoordinator,
+        entry_unique_id: str,
+        probe_number: int,
+    ) -> None:
+        super().__init__(coordinator, entry_unique_id)
+        self.probe_number = probe_number
+        self._attr_unique_id = f"probe{probe_number}_target_reached_{entry_unique_id}"
+        label = probe_label(coordinator.has_mpc, probe_number)
+        self._attr_name = f"{label} target reached"
+
+    @property
+    def is_on(self) -> bool:
+        data = self.coordinator.data or {}
+        temperature = data.get(f"p{self.probe_number}Temp")
+        target = self.coordinator.probe_target(self.probe_number)
+        if not isinstance(temperature, (int, float)) or target is None:
+            return False
+        return temperature >= target

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -111,3 +111,84 @@ async def test_connectivity_reports_offline_instead_of_vanishing(
     state = hass.states.get(_entity_id("Connectivity"))
     assert state is not None
     assert state.state == "off"
+
+
+async def test_a_target_reached_sensor_per_probe(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+) -> None:
+    """PBV4PS2 has two probes, so there is no third or fourth."""
+    await mock_add_config_entry()
+    assert hass.states.get(_entity_id("MPC target reached")) is not None
+    assert hass.states.get(_entity_id("P2 target reached")) is not None
+    assert hass.states.get(_entity_id("P3 target reached")) is None
+
+
+async def test_target_reached_follows_the_probe(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+) -> None:
+    entry = await mock_add_config_entry()
+    coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+
+    coordinator.async_set_updated_data({"p1Temp": 70, "p1Target": 165})
+    await hass.async_block_till_done()
+    state = hass.states.get(_entity_id("MPC target reached"))
+    assert state is not None
+    assert state.state == "off"
+
+    coordinator.async_set_updated_data({"p1Temp": 165, "p1Target": 165})
+    await hass.async_block_till_done()
+    state = hass.states.get(_entity_id("MPC target reached"))
+    assert state is not None
+    assert state.state == "on"
+
+
+async def test_target_reached_is_off_rather_than_unknown(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+) -> None:
+    """An automation on off-to-on cannot trigger out of `unknown`.
+
+    So an unplugged probe, or one with no target, reads `off` rather than
+    reporting that it does not know.
+    """
+    entry = await mock_add_config_entry()
+    coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+
+    # Probe plugged in, no target anywhere.
+    coordinator.async_set_updated_data({"p2Temp": 70})
+    await hass.async_block_till_done()
+    state = hass.states.get(_entity_id("P2 target reached"))
+    assert state is not None
+    assert state.state == "off"
+
+    # Target set, no probe in the port.
+    coordinator.restored_targets[2] = 165
+    coordinator.async_set_updated_data({"p2Temp": None})
+    await hass.async_block_till_done()
+    state = hass.states.get(_entity_id("P2 target reached"))
+    assert state is not None
+    assert state.state == "off"
+
+
+async def test_target_reached_uses_a_target_the_grill_does_not_report(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+) -> None:
+    """The point of the sensor: probes the grill raises nothing for."""
+    entry = await mock_add_config_entry()
+    coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator.restored_targets[2] = 165
+
+    coordinator.async_set_updated_data({"p2Temp": 164})
+    await hass.async_block_till_done()
+    state = hass.states.get(_entity_id("P2 target reached"))
+    assert state is not None
+    assert state.state == "off"
+
+    coordinator.async_set_updated_data({"p2Temp": 166})
+    await hass.async_block_till_done()
+    state = hass.states.get(_entity_id("P2 target reached"))
+    assert state is not None
+    assert state.state == "on"


### PR DESCRIPTION
Set 6 of #321, last of three. Builds on #341, which landed the targets this reads.

The grill acts on the control probe only, so it raises nothing for the rest — and #341 gave every probe a target it can hold, from three sources: one the board reports, one in its virtual data store, or one restored here across a restart. This turns those into a signal to automate on.

One binary sensor per probe, up to `meat_probes`, comparing the reported temperature against `coordinator.probe_target()` — so it works for probes the grill knows nothing about, which is the point.

**Deliberately `off` rather than unknown when there is no probe or no target.** An automation triggering on off-to-on does not fire reliably out of `unknown` or `unavailable`, and this entity exists to be triggered on. Reporting "I don't know" would be more honest and less useful; the state means "not reached", which is true in both cases.

That is also why there is no `available` override here. On the earlier version of #341 I had one that returned the parent unchanged to hang a comment on, and you were right that a property which looks like it does something is worse than a comment on the class. The reasoning is in the class docstring instead.

Four tests:

- one sensor per probe, and no third on a two-probe grill
- follows a board-reported target across the threshold
- **`off` rather than unknown** for an unplugged probe, and for a probe with no target
- **a target the grill does not report at all** — set only in `restored_targets`, crossing 165 from 164 to 166

I verified the last one has teeth by reading the target straight from `data["pNTarget"]` instead of through `probe_target()`: it fails, and nothing else does. That is the test that distinguishes this from a sensor that only works on the control probe.

112 tests, ruff, `ruff format --check` and mypy clean on current `main`.

With this, sets 1, 2, 3, 4, 5, 6 and 8 from #321 are complete. Set 7 is the local transport, adaptive polling and reauth, tracked separately in #344 — and the transport half of it is now largely your #543.
