### PR TITLE
Expose whether the grill has a meat probe control port

### DIFF
--- a/custom_components/pitboss/binary_sensor.py
+++ b/custom_components/pitboss/binary_sensor.py
@@ -123,6 +123,7 @@ async def async_setup_entry(
     for entity_description in ENTITY_DESCRIPTIONS:
         entities.append(BinarySensor(coordinator, entry.unique_id, entity_description))
     entities.append(ConnectivitySensor(coordinator, entry.unique_id))
+    entities.append(MeatProbeControlSensor(coordinator, entry.unique_id))
     for probe_number in range(1, (coordinator.api.spec.meat_probes or 0) + 1):
         entities.append(
             ProbeTargetReachedSensor(coordinator, entry.unique_id, probe_number)
@@ -184,6 +185,39 @@ class ConnectivitySensor(BaseEntity, BinarySensorEntity):
     @property
     def is_on(self) -> bool:
         return bool(self.coordinator.api) and self.coordinator.api.is_connected()
+
+
+class MeatProbeControlSensor(BaseEntity, BinarySensorEntity):
+    """Whether the grill has a meat probe control port.
+
+    A static property of the model, from the vendor's catalogue. The port
+    naming already says it to a person reading the dashboard -- probe 1 is
+    called MPC -- but an automation cannot read an entity's name, and
+    "does this grill act on a probe at all" is the question behind most of
+    what one would do with these entities.
+
+    Always available: the answer does not depend on the grill being reachable.
+    """
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_icon = "mdi:thermometer-check"
+
+    def __init__(
+        self,
+        coordinator: PitBossDataUpdateCoordinator,
+        entry_unique_id: str,
+    ) -> None:
+        super().__init__(coordinator, entry_unique_id)
+        self._attr_unique_id = f"has_mpc_{entry_unique_id}"
+        self._attr_name = "Meat probe control"
+
+    @property
+    def available(self) -> bool:
+        return True
+
+    @property
+    def is_on(self) -> bool:
+        return self.coordinator.has_mpc
 
 
 class ProbeTargetReachedSensor(BaseEntity, BinarySensorEntity):

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -1,4 +1,5 @@
 from collections.abc import Awaitable, Callable
+from dataclasses import replace
 from unittest.mock import Mock
 
 import pytest
@@ -190,5 +191,48 @@ async def test_target_reached_uses_a_target_the_grill_does_not_report(
     coordinator.async_set_updated_data({"p2Temp": 166})
     await hass.async_block_till_done()
     state = hass.states.get(_entity_id("P2 target reached"))
+    assert state is not None
+    assert state.state == "on"
+
+
+async def test_meat_probe_control_sensor(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+) -> None:
+    """PBV4PS2 has a control port, so it reads `on`."""
+    await mock_add_config_entry()
+    state = hass.states.get(_entity_id("Meat probe control"))
+    assert state is not None
+    assert state.state == "on"
+
+
+async def test_meat_probe_control_sensor_without_a_control_port(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+    mock_pitboss: Mock,
+) -> None:
+    """The module parametrizes `model`, so the spec is swapped instead."""
+    mock_pitboss.spec = replace(mock_pitboss.spec, has_mpc=False)
+
+    await mock_add_config_entry()
+
+    state = hass.states.get(_entity_id("Meat probe control"))
+    assert state is not None
+    assert state.state == "off"
+
+
+async def test_meat_probe_control_stays_available_while_disconnected(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+    mock_pitboss: Mock,
+) -> None:
+    """It answers a question about the model, not about the connection."""
+    entry = await mock_add_config_entry()
+    coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    mock_pitboss.is_connected.return_value = False
+    coordinator.async_set_updated_data({})
+    await hass.async_block_till_done()
+
+    state = hass.states.get(_entity_id("Meat probe control"))
     assert state is not None
     assert state.state == "on"


### PR DESCRIPTION
The last unshipped half of item 12 in #321. That item was "label probe ports MPC / MP1 / MP2 … **plus a capability sensor**"; #333 landed the labels and I never sent the sensor. Going through the roadmap to close it out is what surfaced it.

A binary sensor for `Grill.has_mpc` — whether the grill has a meat probe control port, and therefore whether probe 1 is the one the board acts on.

**It is partly redundant and I want to be upfront about that.** #333 already says it to anyone reading a dashboard: the entity is called MPC. What a name cannot do is be read by an automation, and "does this grill act on a probe at all" is the question behind most of what the probe entities are for — whether a target will be enforced or is only a note.

If you think the naming carries it, say so and I will drop this; it is the one roadmap item where I would not argue hard.

Always available, like `ConnectivitySensor`, because it answers a question about the model rather than about the connection — a grill being unreachable does not make it stop having the port. There is a test for that.

Three tests: on for a grill with the port, off for one without, and available while disconnected. The second swaps the spec with `dataclasses.replace` rather than parametrizing the model, because `test_binary_sensor.py` sets `model` at module level and a second `parametrize` on the same argument is a collection error.

115 tests, ruff, `ruff format --check` and mypy clean on current `main`.

**With this, every item in #321 that belongs in this repo is shipped.** 1–15 and 19 are in `main`; 16–18 are set 7 and live in #344, where the transport half is now your #543.
