### PR TITLE
Ask for the password when the grill rejects it

### DIFF
--- a/custom_components/pitboss/config_flow.py
+++ b/custom_components/pitboss/config_flow.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import Any
 
 import voluptuous as vol
@@ -106,6 +107,35 @@ class PitBossFlowHandler(ConfigFlow, domain=DOMAIN):
                 }
             ),
             description_placeholders={"name": self._device_id},
+        )
+
+    async def async_step_reauth(
+        self, entry_data: Mapping[str, Any]
+    ) -> ConfigFlowResult:
+        """Handle a password the grill no longer accepts."""
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Ask for the grill's current password.
+
+        Optional and defaulting to empty, because clearing the password on the
+        grill is a supported thing to do -- the firmware treats an empty one
+        as no authentication at all.
+        """
+        reauth_entry = self._get_reauth_entry()
+        if user_input is not None:
+            return self.async_update_reload_and_abort(
+                reauth_entry,
+                data_updates={CONF_PASSWORD: user_input.get(CONF_PASSWORD, "")},
+            )
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=vol.Schema({vol.Optional(CONF_PASSWORD, default=""): str}),
+            description_placeholders={
+                "name": reauth_entry.data.get(CONF_DEVICE_ID, "")
+            },
         )
 
     async def async_step_reconfigure(

--- a/custom_components/pitboss/coordinator.py
+++ b/custom_components/pitboss/coordinator.py
@@ -6,6 +6,7 @@ from time import monotonic
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from pytboss.api import PitBoss
@@ -13,6 +14,7 @@ from pytboss.exceptions import (
     GrillUnavailable,
     NotConnectedError,
     RPCError,
+    Unauthorized,
     UnsupportedOperation,
 )
 from pytboss.grills import StateDict
@@ -234,5 +236,13 @@ class PitBossDataUpdateCoordinator(DataUpdateCoordinator[StateDict]):
             return state
         except NotConnectedError as ex:
             raise UpdateFailed("Grill not connected") from ex
+        except Unauthorized as ex:
+            # The grill rejected the password rather than failing the call.
+            # Retrying cannot fix that, and on a transport where `PB.GetState`
+            # is itself password-gated it takes the whole integration down --
+            # so ask for the password instead of retrying forever.
+            raise ConfigEntryAuthFailed(
+                "The grill rejected the stored password"
+            ) from ex
         except RPCError as ex:
             raise UpdateFailed(str(ex)) from ex

--- a/custom_components/pitboss/translations/en.json
+++ b/custom_components/pitboss/translations/en.json
@@ -4,7 +4,8 @@
     "abort": {
       "already_configured": "Grill is already configured",
       "reconfigure_successful": "Re-configuration was successful",
-      "unknown_grill": "Unknown grill type: {control_board}"
+      "unknown_grill": "Unknown grill type: {control_board}",
+      "reauth_successful": "Re-authentication was successful"
     },
     "step": {
       "bluetooth_confirm": {
@@ -40,6 +41,13 @@
           "model": "The model is needed to properly communicate with your grill",
           "password": "The password for your grill, NOT your PitBoss account",
           "protocol": "The protocol to use to connect to your grill."
+        }
+      },
+      "reauth_confirm": {
+        "title": "Re-enter the grill password",
+        "description": "{name} rejected the stored password. Enter the password set on the grill, or leave it empty if the grill has none.",
+        "data": {
+          "password": "Password"
         }
       }
     }

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -225,3 +225,43 @@ async def test_reconfigure_flow_updates_entry(
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reconfigure_successful"
     assert entry.data[CONF_PASSWORD] == "newpw"
+
+
+@pytest.mark.parametrize("model", ["PBV4PS2"])
+async def test_reauth_updates_the_password_and_reloads(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_pitboss: Mock,
+) -> None:
+    mock_config_entry.add_to_hass(hass)
+
+    result = await mock_config_entry.start_reauth_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_PASSWORD: "newpassword"}
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+    assert mock_config_entry.data[CONF_PASSWORD] == "newpassword"
+
+
+@pytest.mark.parametrize("model", ["PBV4PS2"])
+async def test_reauth_accepts_an_empty_password(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_pitboss: Mock,
+) -> None:
+    """Clearing the grill's password is supported; the firmware treats an
+    empty one as no authentication at all."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await mock_config_entry.start_reauth_flow(hass)
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert mock_config_entry.data[CONF_PASSWORD] == ""

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -5,7 +5,7 @@ import pytest
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_DEVICE_ID, CONF_MODEL, CONF_PASSWORD, CONF_PROTOCOL
 from homeassistant.core import HomeAssistant
-from pytboss.exceptions import GrillUnavailable
+from pytboss.exceptions import GrillUnavailable, RPCError, Unauthorized
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.pitboss.const import DOMAIN, PROTOCOL_BLE, PROTOCOL_WSS
@@ -171,3 +171,59 @@ async def test_setup_entry_releases_transport_on_unexpected_error(
     mock_wss_conn.disconnect.assert_awaited_once()
     mock_pitboss.stop.assert_awaited_once()
     assert entry.entry_id not in hass.data.get(DOMAIN, {})
+
+
+async def test_a_rejected_password_asks_for_a_new_one(
+    hass: HomeAssistant, mock_pitboss: Mock, mock_wss_conn: Mock
+) -> None:
+    """Retrying cannot fix a wrong password.
+
+    On a transport where `PB.GetState` is itself password-gated a stale
+    password takes the whole integration down, so the entry goes into
+    reauth rather than retrying forever.
+    """
+    mock_pitboss.get_state.side_effect = Unauthorized("Unauthorized", 401)
+
+    entry = MockConfigEntry(
+        title="title",
+        domain=DOMAIN,
+        data={
+            CONF_DEVICE_ID: "mygrill",
+            CONF_MODEL: "PBV4PS2",
+            CONF_PASSWORD: "wrongpassword",
+            CONF_PROTOCOL: PROTOCOL_WSS,
+        },
+        unique_id="mygrillid",
+    )
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.SETUP_ERROR
+    flows = hass.config_entries.flow.async_progress()
+    assert [f["context"]["source"] for f in flows] == ["reauth"]
+
+
+async def test_other_rpc_errors_do_not_ask_for_a_password(
+    hass: HomeAssistant, mock_pitboss: Mock, mock_wss_conn: Mock
+) -> None:
+    """Only a 401 means the password is wrong."""
+    mock_pitboss.get_state.side_effect = RPCError("something else", -1)
+
+    entry = MockConfigEntry(
+        title="title",
+        domain=DOMAIN,
+        data={
+            CONF_DEVICE_ID: "mygrill",
+            CONF_MODEL: "PBV4PS2",
+            CONF_PASSWORD: "asdfasdf",
+            CONF_PROTOCOL: PROTOCOL_WSS,
+        },
+        unique_id="mygrillid",
+    )
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.SETUP_RETRY
+    assert hass.config_entries.flow.async_progress() == []


### PR DESCRIPTION
Item 18 of #321, tracked in #344. **Independent of the options-flow question** — reauth is a config flow step, not an options one, so it does not touch #277 or wait on it. The other two items in #344 are the local transport (now your pytboss#543) and adaptive polling (which does want the flow).

`PB.GetState` is password-gated. A stale password therefore does not just break writes — it takes the whole integration down, and today it retries forever without ever saying why.

This raises `ConfigEntryAuthFailed` on a rejected password, so Home Assistant asks for a new one instead:

```python
except Unauthorized as ex:
    raise ConfigEntryAuthFailed("The grill rejected the stored password") from ex
except RPCError as ex:
    raise UpdateFailed(str(ex)) from ex
```

**Clause order matters here and is deliberate.** Since [pytboss#524](https://github.com/dknowles2/pytboss/pull/524), `Unauthorized` subclasses `RPCError` — that was the point, so existing `except RPCError` handlers kept working. It also means catching `RPCError` first would swallow the 401 silently, which is the bug this replaces rather than a new one.

That PR is what made this possible at all. Before it the only way to tell a 401 from any other RPC failure was matching on the message text, which I was doing downstream and would not have proposed here.

**The password field is optional and defaults to empty**, because clearing the grill's password is a supported thing to do — the firmware's `checkPassword` returns true immediately when the stored password is empty, so an empty entry is "no authentication" rather than a blank guess.

Four tests:

- a 401 during setup puts the entry in `SETUP_ERROR` with a `reauth` flow in progress
- **any other `RPCError` does not** — it stays `SETUP_RETRY` with no flow, which is the half that would regress silently if the clause order were ever flipped
- reauth writes the new password to the entry and reloads
- an empty password is accepted

Verified the first fails without the change rather than assuming it would.

119 tests, ruff, `ruff format --check` and mypy clean on current `main`.
