### PR TITLE
Poll faster while the grill is running

### DIFF
--- a/custom_components/pitboss/const.py
+++ b/custom_components/pitboss/const.py
@@ -8,7 +8,18 @@ LOGGER: Logger = getLogger(__package__)
 NAME = "PitBoss"
 DOMAIN = "pitboss"
 MANUFACTURER = NAME
-PING_INTERVAL = timedelta(seconds=30)
+# How often the coordinator polls, depending on what the grill is doing.
+#
+# Nothing interesting changes on a grill sitting in standby, and each cycle
+# costs several round trips -- but once it is lit, temperatures move and the
+# delay is what the user actually feels. Against the flat 30s these replace,
+# an idle day halves its requests and even a four-hour cook makes slightly
+# fewer of them overall.
+#
+# Constants rather than options because this integration has no options flow
+# yet. They are the two values that would become fields when it grows one.
+ACTIVE_SCAN_INTERVAL = timedelta(seconds=10)
+STANDBY_SCAN_INTERVAL = timedelta(seconds=60)
 # Diagnostics change slowly; no need to read them at the poll rate.
 SYS_INFO_INTERVAL = 60.0
 PROTOCOL_WSS = "wss"

--- a/custom_components/pitboss/coordinator.py
+++ b/custom_components/pitboss/coordinator.py
@@ -19,7 +19,13 @@ from pytboss.exceptions import (
 )
 from pytboss.grills import StateDict
 
-from .const import DOMAIN, LOGGER, PING_INTERVAL, SYS_INFO_INTERVAL
+from .const import (
+    ACTIVE_SCAN_INTERVAL,
+    DOMAIN,
+    LOGGER,
+    STANDBY_SCAN_INTERVAL,
+    SYS_INFO_INTERVAL,
+)
 
 
 class PitBossDataUpdateCoordinator(DataUpdateCoordinator[StateDict]):
@@ -38,7 +44,11 @@ class PitBossDataUpdateCoordinator(DataUpdateCoordinator[StateDict]):
     ) -> None:
         """Initialize the coordinator."""
         super().__init__(
-            hass=hass, logger=LOGGER, name=DOMAIN, update_interval=PING_INTERVAL
+            hass=hass,
+            logger=LOGGER,
+            name=DOMAIN,
+            # Starts in standby; the first state that arrives corrects it.
+            update_interval=STANDBY_SCAN_INTERVAL,
         )
         self.device_info = device_info
         self.api = api
@@ -186,9 +196,23 @@ class PitBossDataUpdateCoordinator(DataUpdateCoordinator[StateDict]):
         merged.update(state)
         return merged
 
+    def _apply_poll_interval(self, state: StateDict) -> None:
+        """Poll hard while the grill runs, back off in standby."""
+        wanted = (
+            ACTIVE_SCAN_INTERVAL if state.get("moduleIsOn") else STANDBY_SCAN_INTERVAL
+        )
+        if self.update_interval != wanted:
+            self.logger.debug("Polling every %s", wanted)
+            self.update_interval = wanted
+
     async def _on_state_update(self, data: StateDict) -> None:
         self.logger.debug("Received data: %s", data)
-        self.async_set_updated_data(self._merge_state(data))
+        merged = self._merge_state(data)
+        # Applied on the push path too: on Bluetooth a power change arrives
+        # this way, and the poll interval should follow it without waiting
+        # for the next poll to notice.
+        self._apply_poll_interval(merged)
+        self.async_set_updated_data(merged)
 
     async def _start_api(self) -> None:
         try:
@@ -232,6 +256,7 @@ class PitBossDataUpdateCoordinator(DataUpdateCoordinator[StateDict]):
         # a reconnect if push notifications stop being delivered.
         try:
             state = self._merge_state(await self.api.get_state())
+            self._apply_poll_interval(state)
             await self._async_refresh_probe_targets(state)
             return state
         except NotConnectedError as ex:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -235,6 +235,7 @@ async def test_other_rpc_errors_do_not_ask_for_a_password(
     assert entry.state is ConfigEntryState.SETUP_RETRY
     assert hass.config_entries.flow.async_progress() == []
 
+
 async def test_the_poll_interval_follows_the_grill(
     hass: HomeAssistant,
     mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,4 +1,5 @@
 import asyncio
+from collections.abc import Awaitable, Callable
 from unittest.mock import Mock, patch
 
 import pytest
@@ -8,7 +9,13 @@ from homeassistant.core import HomeAssistant
 from pytboss.exceptions import GrillUnavailable, RPCError, Unauthorized
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.pitboss.const import DOMAIN, PROTOCOL_BLE, PROTOCOL_WSS
+from custom_components.pitboss.const import (
+    ACTIVE_SCAN_INTERVAL,
+    DOMAIN,
+    PROTOCOL_BLE,
+    PROTOCOL_WSS,
+    STANDBY_SCAN_INTERVAL,
+)
 from custom_components.pitboss.coordinator import PitBossDataUpdateCoordinator
 
 pytestmark = pytest.mark.parametrize("model", ["PBV4PS2"])
@@ -227,3 +234,39 @@ async def test_other_rpc_errors_do_not_ask_for_a_password(
 
     assert entry.state is ConfigEntryState.SETUP_RETRY
     assert hass.config_entries.flow.async_progress() == []
+
+async def test_the_poll_interval_follows_the_grill(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+) -> None:
+    """Poll hard while the grill runs, back off in standby."""
+    entry = await mock_add_config_entry()
+    coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    assert coordinator.update_interval == STANDBY_SCAN_INTERVAL
+
+    await coordinator._on_state_update({"moduleIsOn": True})
+    await hass.async_block_till_done()
+    assert coordinator.update_interval == ACTIVE_SCAN_INTERVAL
+
+    await coordinator._on_state_update({"moduleIsOn": False})
+    await hass.async_block_till_done()
+    assert coordinator.update_interval == STANDBY_SCAN_INTERVAL
+
+
+async def test_a_partial_frame_does_not_change_the_interval(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+) -> None:
+    """The board answers with two frames and clears them independently.
+
+    A frame carrying no `moduleIsOn` must not read as "the grill is off" --
+    the merged state is what decides, not the frame in isolation.
+    """
+    entry = await mock_add_config_entry()
+    coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    await coordinator._on_state_update({"moduleIsOn": True, "grillTemp": 100})
+    assert coordinator.update_interval == ACTIVE_SCAN_INTERVAL
+
+    await coordinator._on_state_update({"grillTemp": 105})
+
+    assert coordinator.update_interval == ACTIVE_SCAN_INTERVAL


### PR DESCRIPTION
Item 17 of #344, and **without the options flow** — which removes its dependency on #277 entirely.

Polling is currently a flat 30 s. Nothing interesting changes on a grill sitting in standby and each cycle costs several round trips, but once it is lit the temperatures move and the delay is what the user actually feels. So: **10 s while `moduleIsOn`, 60 s otherwise.**

**This makes fewer network requests, not more**, which is the part I would have got wrong by guessing:

| | now (flat 30 s) | this |
|---|---|---|
| a day with no cooking | 2880 | 1440 |
| a day with a four-hour cook | 2880 | 2640 |

A grill is idle almost all the time, so backing off in standby more than pays for polling hard while it runs. 60 s rather than the 30 s I originally planned for standby is what turns it from roughly neutral into a reduction.

**Constants rather than options.** I had this written against an options flow and held it behind #277; making the two intervals module constants gets the behaviour in now and leaves them as exactly the two fields that would become options later. Nothing here has to change when the flow arrives — the values move, the logic does not.

**Applied on the push path too, not only on poll.** On Bluetooth a power change arrives through `_on_state_update`, and the interval should follow it rather than wait for the next poll to notice.

Two tests, both verified to fail without the change:

- the interval follows the grill on and off
- **a partial frame does not read as "off"** — the board answers with two frames and clears them independently, so a frame carrying no `moduleIsOn` must not back the polling off. The interval is decided from the merged state, not the frame in isolation. Applying it to the raw frame instead makes that test fail and nothing else, which is what makes it worth having.

That second one is the same hazard as #326: a frame that is missing a key is not a frame that says the key is false.

117 tests, ruff, `ruff format --check` and mypy clean on current `main`.

With this, #344 is down to item 16 — the local transport, which is your [pytboss#543](https://github.com/dknowles2/pytboss/pull/543) and waits on a release.
