### PR TITLE
Resolve the grill spec on the advertised control board

### DIFF
--- a/custom_components/pitboss/__init__.py
+++ b/custom_components/pitboss/__init__.py
@@ -23,7 +23,8 @@ from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.typing import ConfigType
-from pytboss import api, ble, wss
+from pytboss import api, ble, grills, wss
+from pytboss.exceptions import InvalidGrill
 from pytboss.transport import Transport
 
 from .const import (
@@ -116,8 +117,27 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     else:
         raise ValueError(f"Unknown protocol: {protocol}")
 
+    # The prefix the grill advertises names its control board, and a few
+    # models were sold on two board generations that do not parse alike.
+    # Resolving by model name alone picks the board the vendor lists most
+    # recently, which is the wrong one for every grill on the older board.
+    control_board: str | None = device_id.split("-")[0]
+    try:
+        await hass.async_add_executor_job(grills.get_grill, model, control_board)
+    except InvalidGrill:
+        # An entry from the era of board remapping can hold a model that was
+        # never sold under the advertised prefix. Resolving by name alone is
+        # what every release so far did, so those keep working unchanged.
+        LOGGER.warning(
+            "Model %s has no variant on control board %s; "
+            "using the vendor's latest listing for it",
+            model,
+            control_board,
+        )
+        control_board = None
+
     pitboss = await hass.async_add_executor_job(
-        lambda: api.PitBoss(conn, model, password=password)
+        lambda: api.PitBoss(conn, model, password=password, control_board=control_board)
     )
     device_info = DeviceInfo(
         identifiers={(DOMAIN, device_id)},

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -120,9 +120,10 @@ def mock_wss_conn() -> Generator[Mock]:
 
 
 @pytest.fixture
-def mock_pitboss(spec: Grill) -> Generator[Mock]:
-    with patch("pytboss.api.PitBoss", autospec=True) as mock_pitboss_cls:
-        api = mock_pitboss_cls.return_value
+def mock_pitboss_cls(spec: Grill) -> Generator[Mock]:
+    """The patched PitBoss class, for asserting on constructor arguments."""
+    with patch("pytboss.api.PitBoss", autospec=True) as mock_cls:
+        api = mock_cls.return_value
         api.spec = spec
         # `config` and `fs` are set in PitBoss.__init__, so autospec does not
         # know about them.
@@ -130,4 +131,9 @@ def mock_pitboss(spec: Grill) -> Generator[Mock]:
         api.config.get_info = AsyncMock(return_value={})
         # autospec gives this a Mock return value; targets are a dict.
         api.get_probe_targets = AsyncMock(return_value={})
-        yield api
+        yield mock_cls
+
+
+@pytest.fixture
+def mock_pitboss(mock_pitboss_cls: Mock) -> Mock:
+    return mock_pitboss_cls.return_value

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -65,6 +65,54 @@ async def test_setup_entry_not_ready_disconnects_and_stops(
     mock_pitboss.stop.assert_awaited_once()
 
 
+async def test_setup_passes_the_advertised_control_board(
+    hass: HomeAssistant, mock_wss_conn: Mock, mock_pitboss_cls: Mock
+) -> None:
+    """The device-id prefix names the board, so setup must resolve with it.
+
+    A few models were sold on two board generations; by name alone pytboss
+    returns the board the vendor lists most recently, which is wrong for
+    every grill on the older one.
+    """
+    mock_pitboss_cls.return_value.get_state.return_value = {}
+    entry = MockConfigEntry(
+        title="title",
+        domain=DOMAIN,
+        data={
+            CONF_DEVICE_ID: "PBL-AABBCC",
+            CONF_MODEL: "PBV4PS2",
+            CONF_PASSWORD: "asdfasdf",
+            CONF_PROTOCOL: PROTOCOL_WSS,
+        },
+        unique_id="pbl-aabbcc",
+    )
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.LOADED
+    assert mock_pitboss_cls.call_args.kwargs["control_board"] == "PBL"
+
+
+async def test_setup_falls_back_when_the_board_has_no_such_model(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+    mock_pitboss_cls: Mock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An entry whose prefix and model do not pair keeps today's behaviour.
+
+    The board-remap workarounds this repo used to ship could store a model
+    that was never sold under the advertised prefix; those entries resolve
+    by name alone, as every release so far did.
+    """
+    entry = await mock_add_config_entry()  # device id "mygrill"
+
+    assert entry.state is ConfigEntryState.LOADED
+    assert mock_pitboss_cls.call_args.kwargs["control_board"] is None
+    assert "has no variant on control board mygrill" in caplog.text
+
+
 async def test_setup_entry_ble_connects_and_forwards_platforms(
     hass: HomeAssistant, mock_pitboss: Mock
 ) -> None:


### PR DESCRIPTION
Fixes #352.

The config flow has always filtered the model picker by the device-id prefix, so the board is known and validated at entry creation — setup just never handed it to pytboss. This passes it through: `PitBoss(conn, model, password=password, control_board=device_id.split("-")[0])`.

For the seven dual-board models this is the difference between the right and the wrong parsing routines; for every single-board model it resolves to exactly the spec it did before, since the pair is unique.

**Fallback, deliberately:** an entry from the era of the board-remap workarounds (#119, removed in #315) can hold a model that was never sold under its advertised prefix. For those, `get_grill(model, prefix)` is checked first and on `InvalidGrill` the board is dropped with a warning, so the entry resolves by name alone — bit-for-bit what every release so far did. No existing install changes behaviour except the dual-board ones being fixed.

Per REVIEW.md this stays on the right side of the boundary: no board is remapped, nothing about frames or models lives here — the advertised prefix is passed through verbatim and pytboss does the resolving.

Test-wise: `conftest.py` splits the `mock_pitboss` fixture so the patched class is available for constructor assertions (`mock_pitboss_cls`), the instance fixture is unchanged. Two new tests: the prefix is passed through when the pair exists, and the fallback engages (with the warning) when it does not.

Verification: full suite green on Linux (123 passed — this environment is macOS, where the suite cannot run natively per AGENTS.md, so it ran in a `python:3.14` container instead); `ruff check`, `ruff format --check` and `mypy .` clean. I cannot verify on hardware — my grill is a PBL `PB1600PS1`, not a dual-board model — but the dual-board resolution difference is reproducible from `grills.json` alone and is quoted in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)