### PR TITLE
Create the firmware sensor up front and retry the failed read

### DIFF
--- a/custom_components/pitboss/coordinator.py
+++ b/custom_components/pitboss/coordinator.py
@@ -166,11 +166,23 @@ class PitBossDataUpdateCoordinator(DataUpdateCoordinator[StateDict]):
         """Set up the coordinator."""
         await self.api.subscribe_state(self._on_state_update)
         await self._start_api()
+        await self._async_refresh_firmware_version()
+
+    async def _async_refresh_firmware_version(self) -> None:
+        """Fetch the firmware version until one read succeeds. Never fatal.
+
+        The version does not change outside a reload, so this is a no-op once
+        known. Retrying until then matters because the read at setup used to
+        be the only attempt: a grill that failed to answer it once had no
+        firmware sensor until the integration was reloaded.
+        """
+        if self.firmware_version is not None:
+            return
         try:
             result = await self.api.get_firmware_version()
             self.firmware_version = result.get("firmwareVersion")
         except Exception as ex:  # noqa: BLE001
-            # Cosmetic; never worth failing setup over.
+            # Cosmetic; never worth failing a refresh over.
             self.logger.debug("Could not fetch the firmware version: %s", ex)
 
     def _merge_state(self, state: StateDict) -> StateDict:
@@ -250,6 +262,7 @@ class PitBossDataUpdateCoordinator(DataUpdateCoordinator[StateDict]):
             raise UpdateFailed("Grill not connected") from ex
 
         await self._async_refresh_sys_info()
+        await self._async_refresh_firmware_version()
 
         # Always fetch the current state to ensure sensors stay up-to-date.
         # Relying solely on push notifications means sensors can go stale after

--- a/custom_components/pitboss/sensor.py
+++ b/custom_components/pitboss/sensor.py
@@ -93,8 +93,7 @@ async def async_setup_entry(
         entities.append(ProbeSensor(coordinator, entry.unique_id, entity_description))
     for description in SYS_INFO_DESCRIPTIONS:
         entities.append(SysInfoSensor(coordinator, entry.unique_id, description))
-    if coordinator.firmware_version:
-        entities.append(FirmwareSensor(coordinator, entry.unique_id))
+    entities.append(FirmwareSensor(coordinator, entry.unique_id))
     if coordinator.api.spec.json.get("has_recipe_functionality", False):
         for entity_description in RECIPE_ENTITY_DESCRIPTIONS:
             entities.append(
@@ -197,7 +196,9 @@ class FirmwareSensor(BaseEntity, SensorEntity):
 
     @property
     def available(self) -> bool:
-        # Read once at setup and unchanging, so it stays readable while the
+        # Unavailable only until the first successful read -- the coordinator
+        # keeps retrying one that failed at setup. Once known the version
+        # cannot change outside a reload, so it stays readable while the
         # grill is away rather than following the connection.
         return self.coordinator.firmware_version is not None
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,16 +1,22 @@
 from collections.abc import Awaitable, Callable
+from datetime import timedelta
 from typing import cast
 from unittest.mock import Mock
 
 import pytest
 from conftest import get_entity
+from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
+from homeassistant.util import dt as dt_util
 from pytboss.grills import StateDict
-from pytest_homeassistant_custom_component.common import MockConfigEntry
+from pytest_homeassistant_custom_component.common import (
+    MockConfigEntry,
+    async_fire_time_changed,
+)
 
-from custom_components.pitboss.const import DOMAIN
+from custom_components.pitboss.const import DOMAIN, STANDBY_SCAN_INTERVAL
 from custom_components.pitboss.coordinator import PitBossDataUpdateCoordinator
 from custom_components.pitboss.sensor import ProbeSensor
 
@@ -135,15 +141,34 @@ async def test_firmware_version_sensor(
 
 
 @pytest.mark.parametrize("model", ["PBV4PS2"])
-async def test_no_firmware_sensor_when_the_grill_does_not_answer(
+async def test_firmware_sensor_recovers_from_a_failed_first_read(
     hass: HomeAssistant,
     mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
     mock_pitboss: Mock,
 ) -> None:
-    """A failed read must not break setup, and creates no entity."""
+    """A failed read must not break setup, and is retried until it works.
+
+    The sensor exists from the start -- merely unavailable -- because a
+    grill that is slow to answer once should not lose the entity until
+    the integration is reloaded.
+    """
     mock_pitboss.get_firmware_version.side_effect = RuntimeError("nope")
     await mock_add_config_entry()
-    assert hass.states.get("sensor.mygrill_firmware_version") is None
+
+    state = hass.states.get("sensor.mygrill_firmware_version")
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE
+
+    mock_pitboss.get_firmware_version.side_effect = None
+    mock_pitboss.get_firmware_version.return_value = {"firmwareVersion": "0.5.7"}
+    async_fire_time_changed(
+        hass, dt_util.utcnow() + STANDBY_SCAN_INTERVAL + timedelta(seconds=1)
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.mygrill_firmware_version")
+    assert state is not None
+    assert state.state == "0.5.7"
 
 
 @pytest.mark.parametrize("model", ["PBV4PS2"])


### PR DESCRIPTION
Fixes #353.

`FirmwareSensor` is now created unconditionally. It reports unavailable until a read succeeds — `available` already keyed off `firmware_version is not None`, so the entity needed no change beyond its comment — and the coordinator retries the read on each poll until one lands, after which it is a no-op: the version cannot change outside a reload.

The retry lives in `_async_refresh_firmware_version`, shaped exactly like `_async_refresh_sys_info` next to it: never fatal, debug-logged on failure. `_async_setup` calls the same method, so the setup path is unchanged apart from the extraction.

`test_no_firmware_sensor_when_the_grill_does_not_answer` pinned the old behaviour in, so it is replaced rather than kept: the new test fails the first read, asserts the sensor exists and is unavailable, then lets the next poll's read succeed and asserts the version appears. The happy-path test (`test_firmware_version_sensor`, including the device `sw_version` assertion) is untouched and still passes.

Known limitation, deliberately out of scope: when the version arrives only after setup, the device-registry `sw_version` field still waits for the next reload — that write happens in `async_setup_entry` and moving it into the coordinator drags device-registry access in there for a purely cosmetic field. The sensor itself is correct either way.

Verification: full suite green on Linux (121 passed — this environment is macOS, where the suite cannot run natively per AGENTS.md, so it ran in a `python:3.14` container instead); `ruff check`, `ruff format --check` and `mypy .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)