### PR TITLE
Gate firmware retries to the diagnostics cadence

### DIFF
--- a/custom_components/pitboss/coordinator.py
+++ b/custom_components/pitboss/coordinator.py
@@ -56,6 +56,10 @@ class PitBossDataUpdateCoordinator(DataUpdateCoordinator[StateDict]):
         # Latest Sys.GetInfo payload from the control board.
         self.sys_info: dict = {}
         self._sys_info_at = 0.0
+        # When the firmware version was last asked for. `None` rather than
+        # 0.0 so the first attempt is never gated: `monotonic()` can be
+        # small at process start, which 0.0 would read as "just tried".
+        self._firmware_attempted_at: float | None = None
         # What the grill is holding, and what we are holding for it. See
         # `probe_target` for why both exist.
         self.probe_targets: dict[int, int] = {}
@@ -175,9 +179,21 @@ class PitBossDataUpdateCoordinator(DataUpdateCoordinator[StateDict]):
         known. Retrying until then matters because the read at setup used to
         be the only attempt: a grill that failed to answer it once had no
         firmware sensor until the integration was reloaded.
+
+        Retries are gated to the diagnostics cadence, like the system info
+        read above. Gating on success alone meant a grill that persistently
+        failed this read was asked again on every poll -- every ten seconds
+        for as long as it was lit, once the poll interval followed the grill.
         """
         if self.firmware_version is not None:
             return
+        now = monotonic()
+        if (
+            self._firmware_attempted_at is not None
+            and now - self._firmware_attempted_at < SYS_INFO_INTERVAL
+        ):
+            return
+        self._firmware_attempted_at = now
         try:
             result = await self.api.get_firmware_version()
             self.firmware_version = result.get("firmwareVersion")

--- a/custom_components/pitboss/coordinator.py
+++ b/custom_components/pitboss/coordinator.py
@@ -166,11 +166,23 @@ class PitBossDataUpdateCoordinator(DataUpdateCoordinator[StateDict]):
         """Set up the coordinator."""
         await self.api.subscribe_state(self._on_state_update)
         await self._start_api()
+        await self._async_refresh_firmware_version()
+
+    async def _async_refresh_firmware_version(self) -> None:
+        """Fetch the firmware version until one read succeeds. Never fatal.
+
+        The version does not change outside a reload, so this is a no-op once
+        known. Retrying until then matters because the read at setup used to
+        be the only attempt: a grill that failed to answer it once had no
+        firmware sensor until the integration was reloaded.
+        """
+        if self.firmware_version is not None:
+            return
         try:
             result = await self.api.get_firmware_version()
             self.firmware_version = result.get("firmwareVersion")
         except Exception as ex:  # noqa: BLE001
-            # Cosmetic; never worth failing setup over.
+            # Cosmetic; never worth failing a refresh over.
             self.logger.debug("Could not fetch the firmware version: %s", ex)
 
     def _merge_state(self, state: StateDict) -> StateDict:
@@ -250,6 +262,7 @@ class PitBossDataUpdateCoordinator(DataUpdateCoordinator[StateDict]):
             raise UpdateFailed("Grill not connected") from ex
 
         await self._async_refresh_sys_info()
+        await self._async_refresh_firmware_version()
 
         # Always fetch the current state to ensure sensors stay up-to-date.
         # Relying solely on push notifications means sensors can go stale after

--- a/custom_components/pitboss/sensor.py
+++ b/custom_components/pitboss/sensor.py
@@ -93,8 +93,7 @@ async def async_setup_entry(
         entities.append(ProbeSensor(coordinator, entry.unique_id, entity_description))
     for description in SYS_INFO_DESCRIPTIONS:
         entities.append(SysInfoSensor(coordinator, entry.unique_id, description))
-    if coordinator.firmware_version:
-        entities.append(FirmwareSensor(coordinator, entry.unique_id))
+    entities.append(FirmwareSensor(coordinator, entry.unique_id))
     if coordinator.api.spec.json.get("has_recipe_functionality", False):
         for entity_description in RECIPE_ENTITY_DESCRIPTIONS:
             entities.append(
@@ -197,7 +196,9 @@ class FirmwareSensor(BaseEntity, SensorEntity):
 
     @property
     def available(self) -> bool:
-        # Read once at setup and unchanging, so it stays readable while the
+        # Unavailable only until the first successful read -- the coordinator
+        # keeps retrying one that failed at setup. Once known the version
+        # cannot change outside a reload, so it stays readable while the
         # grill is away rather than following the connection.
         return self.coordinator.firmware_version is not None
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,16 +1,22 @@
 from collections.abc import Awaitable, Callable
+from datetime import timedelta
 from typing import cast
 from unittest.mock import Mock
 
 import pytest
 from conftest import get_entity
+from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
+from homeassistant.util import dt as dt_util
 from pytboss.grills import StateDict
-from pytest_homeassistant_custom_component.common import MockConfigEntry
+from pytest_homeassistant_custom_component.common import (
+    MockConfigEntry,
+    async_fire_time_changed,
+)
 
-from custom_components.pitboss.const import DOMAIN
+from custom_components.pitboss.const import DOMAIN, STANDBY_SCAN_INTERVAL
 from custom_components.pitboss.coordinator import PitBossDataUpdateCoordinator
 from custom_components.pitboss.sensor import ProbeSensor
 
@@ -135,15 +141,34 @@ async def test_firmware_version_sensor(
 
 
 @pytest.mark.parametrize("model", ["PBV4PS2"])
-async def test_no_firmware_sensor_when_the_grill_does_not_answer(
+async def test_firmware_sensor_recovers_from_a_failed_first_read(
     hass: HomeAssistant,
     mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
     mock_pitboss: Mock,
 ) -> None:
-    """A failed read must not break setup, and creates no entity."""
+    """A failed read must not break setup, and is retried until it works.
+
+    The sensor exists from the start -- merely unavailable -- because a
+    grill that is slow to answer once should not lose the entity until
+    the integration is reloaded.
+    """
     mock_pitboss.get_firmware_version.side_effect = RuntimeError("nope")
     await mock_add_config_entry()
-    assert hass.states.get("sensor.mygrill_firmware_version") is None
+
+    state = hass.states.get("sensor.mygrill_firmware_version")
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE
+
+    mock_pitboss.get_firmware_version.side_effect = None
+    mock_pitboss.get_firmware_version.return_value = {"firmwareVersion": "0.5.7"}
+    async_fire_time_changed(
+        hass, dt_util.utcnow() + STANDBY_SCAN_INTERVAL + timedelta(seconds=1)
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.mygrill_firmware_version")
+    assert state is not None
+    assert state.state == "0.5.7"
 
 
 @pytest.mark.parametrize("model", ["PBV4PS2"])

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -16,7 +16,11 @@ from pytest_homeassistant_custom_component.common import (
     async_fire_time_changed,
 )
 
-from custom_components.pitboss.const import DOMAIN, STANDBY_SCAN_INTERVAL
+from custom_components.pitboss.const import (
+    DOMAIN,
+    STANDBY_SCAN_INTERVAL,
+    SYS_INFO_INTERVAL,
+)
 from custom_components.pitboss.coordinator import PitBossDataUpdateCoordinator
 from custom_components.pitboss.sensor import ProbeSensor
 
@@ -153,14 +157,32 @@ async def test_firmware_sensor_recovers_from_a_failed_first_read(
     the integration is reloaded.
     """
     mock_pitboss.get_firmware_version.side_effect = RuntimeError("nope")
-    await mock_add_config_entry()
+    entry = await mock_add_config_entry()
 
     state = hass.states.get("sensor.mygrill_firmware_version")
     assert state is not None
     assert state.state == STATE_UNAVAILABLE
 
+    # Retries follow the diagnostics cadence, not the poll rate: a poll
+    # landing inside the gate must not ask again.
+    attempts = mock_pitboss.get_firmware_version.await_count
     mock_pitboss.get_firmware_version.side_effect = None
     mock_pitboss.get_firmware_version.return_value = {"firmwareVersion": "0.5.7"}
+    async_fire_time_changed(
+        hass, dt_util.utcnow() + STANDBY_SCAN_INTERVAL + timedelta(seconds=1)
+    )
+    await hass.async_block_till_done()
+
+    assert mock_pitboss.get_firmware_version.await_count == attempts
+    state = hass.states.get("sensor.mygrill_firmware_version")
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE
+
+    # The gate elapses (monotonic time cannot be frozen from a test, so it
+    # is aged directly) and the next poll's read succeeds.
+    coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    assert coordinator._firmware_attempted_at is not None
+    coordinator._firmware_attempted_at -= SYS_INFO_INTERVAL + 1
     async_fire_time_changed(
         hass, dt_util.utcnow() + STANDBY_SCAN_INTERVAL + timedelta(seconds=1)
     )


### PR DESCRIPTION
Follow-up to the review of #355, taking the flagged asymmetry as a decision: retries now follow the diagnostics cadence rather than the poll rate.

An attempt timestamp gates `_async_refresh_firmware_version` to `SYS_INFO_INTERVAL`, the same cadence as the system-info read it was modelled on — reusing that constant rather than minting a new one, since the rationale is identical: diagnostics are not worth a round trip on every poll. A grill that persistently fails the read is now asked at most once a minute instead of on every 10-second poll while lit. The happy path is unchanged: one read, then the success gate makes everything else a no-op.

One deliberate difference from `_async_refresh_sys_info`: the timestamp starts as `None` rather than `0.0`. `monotonic()` can be small at process start, and `0.0` would read as "just tried" and gate the *first* attempt — the sys-info read dodges this by content-checking `self.sys_info` first, which a not-yet-known version cannot do.

The recovery test now covers the gate from both sides: a poll landing inside the interval does not ask again (asserted on the mock's await count, with the entity still unavailable), and once the gate elapses the next poll's read succeeds and the version appears. Monotonic time cannot be frozen from a test, so the gate is aged by adjusting the timestamp directly.

Was stacked on #355; now that it has landed, `main` is merged in (a merge rather than a rewrite, to keep the pushed history append-only) and the diff is just the gate: `coordinator.py` +16, `test_sensor.py` +26.

Verification: full suite green on Linux (123 passed, in a `python:3.14` container — macOS cannot run the suite natively per AGENTS.md); `ruff check`, `ruff format --check` and `mypy .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)