### PR TITLE
Make the connectivity sensor follow the grill, not just the socket

### DIFF
--- a/custom_components/pitboss/binary_sensor.py
+++ b/custom_components/pitboss/binary_sensor.py
@@ -164,6 +164,12 @@ class ConnectivitySensor(BaseEntity, BinarySensorEntity):
     Unlike every other entity this one stays available while the grill is
     disconnected: an entity that disappears cannot say the grill is offline,
     which is the one thing an offline automation needs to hear.
+
+    Reachable means the transport is connected *and* the grill answers
+    polls. The transport alone is not enough: on the cloud protocol
+    `is_connected()` reflects the socket to the vendor's relay, which
+    accepts the connection whether or not the grill is on the other side
+    of it -- so a powered-off grill read as "connected".
     """
 
     _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
@@ -184,7 +190,11 @@ class ConnectivitySensor(BaseEntity, BinarySensorEntity):
 
     @property
     def is_on(self) -> bool:
-        return bool(self.coordinator.api) and self.coordinator.api.is_connected()
+        return (
+            bool(self.coordinator.api)
+            and self.coordinator.api.is_connected()
+            and self.coordinator.last_update_success
+        )
 
 
 class MeatProbeControlSensor(BaseEntity, BinarySensorEntity):

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -114,6 +114,34 @@ async def test_connectivity_reports_offline_instead_of_vanishing(
     assert state.state == "off"
 
 
+async def test_connectivity_follows_the_grill_not_just_the_socket(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+    mock_pitboss: Mock,
+) -> None:
+    """A connected transport whose grill stops answering is not reachable.
+
+    On the cloud protocol `is_connected()` reflects the socket to the
+    vendor's relay, which stays open whether or not the grill is behind
+    it -- a powered-off grill read as "connected" until this check also
+    asked whether polls succeed.
+    """
+    entry = await mock_add_config_entry()
+    coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    mock_pitboss.is_connected.return_value = True
+    coordinator.async_set_updated_data({})
+    await hass.async_block_till_done()
+    state = hass.states.get(_entity_id("Connectivity"))
+    assert state is not None
+    assert state.state == "on"
+
+    coordinator.async_set_update_error(TimeoutError("grill gone"))
+    await hass.async_block_till_done()
+    state = hass.states.get(_entity_id("Connectivity"))
+    assert state is not None
+    assert state.state == "off"
+
+
 async def test_a_target_reached_sensor_per_probe(
     hass: HomeAssistant,
     mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],


### PR DESCRIPTION
Fixes #357.

`is_on` now requires `coordinator.last_update_success` alongside `api.is_connected()`: the transport can only vouch for its own socket, and on the cloud protocol that socket is to the vendor's relay, which accepts the connection whether or not the grill is behind it. Whether the grill answers polls is the liveness signal, and only the coordinator has it — which is why this composes here rather than in pytboss.

On Bluetooth this changes nothing in practice (a connected grill answers its pings; a dropped link already flips `is_connected()`). On the cloud protocol the sensor stops reporting a powered-off grill as Connected, at the cost of detection moving to poll granularity — up to one poll interval plus the 10s ping timeout. It also gives the sensor one meaning across transports, which matters as #344 / pytboss#543 add a third: `is_connected()` differs per transport, `last_update_success` does not.

New test drives exactly the lying case: transport still connected, polls start failing (`async_set_update_error`), sensor goes off. The existing socket-drop test is untouched and still passes.

Class docstring records the reasoning, since "why is this not just `is_connected()`" is the first question the code now raises.

Verification: full suite green on Linux (124 passed, `python:3.14` container — macOS cannot run the suite natively per AGENTS.md); `ruff check`, `ruff format --check`, `mypy .` clean. The relay's accept-anything behaviour is established from the firmware source and direct connections to the relay, not a live powered-off-grill `wss` session — the caveat is in #357.

🤖 Generated with [Claude Code](https://claude.com/claude-code)