### PR TITLE
Sensor and setup housekeeping

### DIFF
--- a/custom_components/pitboss/__init__.py
+++ b/custom_components/pitboss/__init__.py
@@ -136,9 +136,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         )
         control_board = None
 
-    pitboss = await hass.async_add_executor_job(
-        lambda: api.PitBoss(conn, model, password=password, control_board=control_board)
-    )
+    # Constructed inline: since spec resolution moved into `start()`, the
+    # constructor only assigns attributes. The executor job it ran in was a
+    # holdover from when it read the grill catalogue.
+    pitboss = api.PitBoss(conn, model, password=password, control_board=control_board)
     device_info = DeviceInfo(
         identifiers={(DOMAIN, device_id)},
         name=device_id,

--- a/custom_components/pitboss/sensor.py
+++ b/custom_components/pitboss/sensor.py
@@ -58,7 +58,7 @@ class RecipeSensorEntityDescription(SensorEntityDescription):
     """Describes a PitBoss recipe sensor."""
 
     key: Literal["recipeTime", "recipeStep"]
-    state_class: SensorStateClass = SensorStateClass.MEASUREMENT
+    state_class: SensorStateClass | None = SensorStateClass.MEASUREMENT
 
 
 RECIPE_ENTITY_DESCRIPTIONS = (
@@ -68,6 +68,9 @@ RECIPE_ENTITY_DESCRIPTIONS = (
         icon="mdi:clock-outline",
         device_class=SensorDeviceClass.DURATION,
         native_unit_of_measurement=UnitOfTime.SECONDS,
+        # A countdown, not a measurement: long-term statistics of "seconds
+        # remaining" mean nothing.
+        state_class=None,
     ),
     RecipeSensorEntityDescription(
         key="recipeStep",
@@ -174,8 +177,10 @@ class RecipeSensor(BaseSensorEntity):
 
     @property
     def available(self) -> bool:
+        # Missing defaults to off, matching how the power switch reads the
+        # same key; this class alone assumed on.
         if data := self.coordinator.data:
-            return data.get("moduleIsOn", True) and super().available
+            return data.get("moduleIsOn", False) and super().available
         return super().available
 
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -51,6 +51,24 @@ async def test_recipe_sensors_created_when_supported(
     assert hass.states.get("sensor.mygrill_recipe_step") is not None
 
 
+@pytest.mark.parametrize("model", ["PBV4PS2"])
+async def test_recipe_time_records_no_statistics(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+) -> None:
+    """A countdown is not a measurement; statistics of it mean nothing."""
+    entry = await mock_add_config_entry()
+    coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator.async_set_updated_data(
+        cast(StateDict, {"moduleIsOn": True, "recipeTime": 90})
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get("sensor.mygrill_recipe_time")
+    assert state is not None
+    assert state.state == "90"
+    assert "state_class" not in state.attributes
+
+
 @pytest.mark.parametrize("model", ["PB2180LK"])
 async def test_recipe_sensors_absent_when_unsupported(
     hass: HomeAssistant,
@@ -109,6 +127,14 @@ async def test_recipe_sensor_availability(
     state = hass.states.get("sensor.mygrill_recipe_step")
     assert state is not None
     assert state.state == "2"
+
+    # A frame that carries no moduleIsOn reads as off, the same default the
+    # power switch applies to the same key.
+    coordinator.async_set_updated_data(cast(StateDict, {"recipeStep": 2}))
+    await hass.async_block_till_done()
+    state = hass.states.get("sensor.mygrill_recipe_step")
+    assert state is not None
+    assert state.state == "unavailable"
 
 
 @pytest.mark.parametrize("model", ["PBV4PS2"])


### PR DESCRIPTION
Three small cleanups from a pass over the sensor platform and setup path. None changes what a working grill reports; no issue filed since none has a user-visible failure mode worth one.

**`recipeTime` loses its `MEASUREMENT` state class.** It is a countdown; long-term statistics of "seconds remaining" mean nothing and pollute the statistics tables. The dataclass default stays for `recipeStep`; the description overrides it with `None`. One consequence to know about: entities that already recorded statistics have them orphaned, and Home Assistant shows the standard repair offering to drop them — that is the intended outcome, not a regression.

**`RecipeSensor.available` read a missing `moduleIsOn` as on.** The power switch reads the same key as off (`data.get("moduleIsOn", False)`). Off wins for consistency — a frame that does not carry the key should not read as "the grill is on" in one place and "off" in another. Reachable only on a partial frame before the merged state has seen the key once, so in practice this is about the two code paths agreeing rather than observable behaviour.

**The `PitBoss` constructor is built inline.** The executor job around it was a holdover from when the constructor read the grill catalogue; spec resolution moved into `start()` long ago and the constructor only assigns attributes now. The `get_grill` validation call above it stays in the executor — that one does touch the catalogue.

Both behaviour tweaks are pinned by tests: `recipe_time` state carries no `state_class` attribute, and a frame without `moduleIsOn` reads unavailable.

Verification: full suite green on Linux (124 passed, `python:3.14` container — macOS cannot run the suite natively per AGENTS.md); `ruff check`, `ruff format --check`, `mypy .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)