### PR TITLE
Build the config flow's model list off the event loop

### DIFF
--- a/custom_components/pitboss/config_flow.py
+++ b/custom_components/pitboss/config_flow.py
@@ -15,6 +15,14 @@ from pytboss import grills
 from .const import ALL_PROTOCOLS, DEFAULT_PROTOCOL, DOMAIN, LOGGER
 
 
+def _models_on_board(control_board: str) -> list[str]:
+    """Model names this control board is sold under.
+
+    A module-level function so it can be handed to the executor.
+    """
+    return [g.name for g in grills.get_grills(control_board=control_board)]
+
+
 class PitBossFlowHandler(ConfigFlow, domain=DOMAIN):
     """Config flow for PitBoss."""
 
@@ -76,9 +84,9 @@ class PitBossFlowHandler(ConfigFlow, domain=DOMAIN):
                     CONF_PROTOCOL: user_input.get(CONF_PROTOCOL, DEFAULT_PROTOCOL),
                 },
             )
-        return self._show_more_info_form("more_info")
+        return await self._show_more_info_form("more_info")
 
-    def _show_more_info_form(
+    async def _show_more_info_form(
         self,
         step_id: str,
         model: str | vol.Undefined = vol.UNDEFINED,
@@ -87,7 +95,12 @@ class PitBossFlowHandler(ConfigFlow, domain=DOMAIN):
     ) -> ConfigFlowResult:
         """Show the more_info form."""
         control_board = self._device_id.split("-")[0]
-        models = [g.name for g in grills.get_grills(control_board=control_board)]
+        # In the executor, as `async_setup_entry` already does for
+        # `get_grill`: the first of these reads and parses `grills.json`,
+        # which is ~180 kB. On a fresh install this is what pays that cost,
+        # since there is no entry yet whose setup could have warmed the
+        # cache.
+        models = await self.hass.async_add_executor_job(_models_on_board, control_board)
         if not models:
             return self.async_abort(
                 reason="unknown_grill",
@@ -159,4 +172,4 @@ class PitBossFlowHandler(ConfigFlow, domain=DOMAIN):
         model = reconfigure_entry.data[CONF_MODEL]
         password = reconfigure_entry.data.get(CONF_PASSWORD, "")
         protocol = reconfigure_entry.data.get(CONF_PROTOCOL, DEFAULT_PROTOCOL)
-        return self._show_more_info_form("reconfigure", model, password, protocol)
+        return await self._show_more_info_form("reconfigure", model, password, protocol)

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,3 +1,4 @@
+import threading
 from unittest.mock import Mock
 
 import pytest
@@ -265,3 +266,33 @@ async def test_reauth_accepts_an_empty_password(
 
     assert result["type"] is FlowResultType.ABORT
     assert mock_config_entry.data[CONF_PASSWORD] == ""
+
+
+async def test_model_list_is_built_off_the_event_loop(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Reading the model list parses ~180 kB of JSON off disk.
+
+    `async_setup_entry` already hands the equivalent call to the executor.
+    This is the path that pays the cost first, though: on a fresh install
+    there is no entry yet whose setup could have warmed the cache.
+    """
+    loop_thread = threading.current_thread()
+    called_on: list[threading.Thread] = []
+    real_get_grills = grills.get_grills
+
+    def recording_get_grills(*args, **kwargs):
+        called_on.append(threading.current_thread())
+        return real_get_grills(*args, **kwargs)
+
+    monkeypatch.setattr(grills, "get_grills", recording_get_grills)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_DEVICE_ID: "PBL-1234"}
+    )
+
+    assert called_on, "the model list was never built"
+    assert loop_thread not in called_on


### PR DESCRIPTION
`_show_more_info_form` called `grills.get_grills()` inline:

```python
models = [g.name for g in grills.get_grills(control_board=control_board)]
```

The first such call reads and parses `grills.json` — about 180 kB — and then builds a `Grill` for every model on that board, each of which runs the JS-scrubbing regexes. `async_setup_entry` already hands the equivalent `get_grill()` call to the executor; this path was missed.

It is also the path that pays the cost. `_get_grills()` is `@cache`d, but on a fresh install there is no entry yet whose setup could have warmed it, so the config flow is exactly where the parse happens and where Home Assistant's blocking-call detector fires.

## The change

The lookup moves to a module-level helper handed to `async_add_executor_job`, which makes `_show_more_info_form` a coroutine. Both callers were already `async`, so they just gained an `await`.

## Testing

The new test records which thread `get_grills` runs on and asserts it is not the event loop's. It **fails on the unpatched code** — I checked by restoring `config_flow.py` from `main` and keeping the test.

126 pass, `ruff check`, `ruff format --check` and `mypy .` clean.

One note on how I ran them: the suite does not start on macOS — setting up the `bluetooth` component fails in `dbus_fast` with `'NoneType' object is not callable`, which takes 110 of the 125 tests with it. I ran everything in a Linux container instead, matching what CI does, and confirmed the baseline was green there before changing anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)