### PR TITLE
Hold a probe target we set until the grill reports it

### DIFF
--- a/custom_components/pitboss/const.py
+++ b/custom_components/pitboss/const.py
@@ -51,3 +51,11 @@ def probe_label(has_mpc: bool, probe_number: int) -> str:
     if not has_mpc:
         return f"Probe {probe_number}"
     return "MPC" if probe_number == 1 else f"P{probe_number}"
+
+
+MCU_SETTLE_SECONDS = 6
+"""Seconds to show a value we asked for before believing the grill again.
+
+The board wipes its cached status the moment it forwards a command to the
+MCU, so the next poll still carries the old value and an entity that read it
+straight back would appear to snap to the previous setting."""

--- a/custom_components/pitboss/number.py
+++ b/custom_components/pitboss/number.py
@@ -7,8 +7,9 @@ from homeassistant.components.number import NumberEntityDescription, RestoreNumb
 from homeassistant.components.number.const import NumberDeviceClass
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfTemperature
-from homeassistant.core import HomeAssistant
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.event import async_call_later
 from homeassistant.util.unit_conversion import TemperatureConverter
 
 from .const import (
@@ -17,6 +18,7 @@ from .const import (
     DEFAULT_PROBE_MAX_TEMP,
     DEFAULT_PROBE_MIN_TEMP,
     DOMAIN,
+    MCU_SETTLE_SECONDS,
     probe_label,
 )
 from .coordinator import PitBossDataUpdateCoordinator
@@ -76,6 +78,8 @@ class TargetProbeTemperature(BaseEntity, RestoreNumber):
         self._attr_unique_id = f"{entity_description.key}_{entry_unique_id}"
         label = probe_label(coordinator.has_mpc, entity_description.probe_number)
         self._attr_name = f"{label} target"
+        self._pending_value: int | None = None
+        self._cancel_settle: CALLBACK_TYPE | None = None
 
     async def async_added_to_hass(self) -> None:
         """Restore the target we last set for this probe.
@@ -85,6 +89,9 @@ class TargetProbeTemperature(BaseEntity, RestoreNumber):
         restart. Anything the grill is holding wins over the restored value.
         """
         await super().async_added_to_hass()
+        # Registered once rather than per set: `async_on_remove` only appends,
+        # so re-registering would grow the list for the life of the entity.
+        self.async_on_remove(self._cancel_pending_settle)
         probe_number = self.entity_description.probe_number
         if self.coordinator.probe_target(probe_number) is not None:
             return
@@ -100,6 +107,12 @@ class TargetProbeTemperature(BaseEntity, RestoreNumber):
                 value, stored_unit, self.coordinator.grill_unit
             )
         self.coordinator.note_restored_target(probe_number, round(value))
+
+    @callback
+    def _cancel_pending_settle(self) -> None:
+        if self._cancel_settle is not None:
+            self._cancel_settle()
+            self._cancel_settle = None
 
     @property
     def native_unit_of_measurement(self) -> str:
@@ -119,15 +132,53 @@ class TargetProbeTemperature(BaseEntity, RestoreNumber):
 
         Deliberately an int: coercing to float would render the state as
         "165.0" where it has always been "165".
+
+        Shows what we asked for until the grill confirms it. `probe_target`
+        puts the board's own `pNTarget` first, and that is still the previous
+        value for as long as it takes the board to report the new one, so
+        reading it straight back would make the slider snap to the old
+        setting.
         """
+        if self._pending_value is not None:
+            return self._pending_value
         return self.coordinator.probe_target(self.entity_description.probe_number)
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        if self._pending_value is not None and (
+            self.coordinator.probe_target(self.entity_description.probe_number)
+            == self._pending_value
+        ):
+            self._pending_value = None
+        super()._handle_coordinator_update()
 
     async def async_set_native_value(self, value: float) -> None:
         """Set the target, by whichever route this probe supports."""
+        target = round(value)
         await self.coordinator.async_set_probe_target(
-            self.entity_description.probe_number, round(value)
+            self.entity_description.probe_number, target
         )
+        self._pending_value = target
+        # Siblings read the coordinator too -- the target-reached sensor
+        # follows the grill rather than this pending value.
         self.coordinator.async_update_listeners()
+        # A second set inside the window replaces the timer rather than
+        # queueing another.
+        self._cancel_pending_settle()
+        self._cancel_settle = async_call_later(
+            self.hass, MCU_SETTLE_SECONDS, self._async_confirm
+        )
+
+    async def _async_confirm(self, _now) -> None:
+        self._cancel_settle = None
+        await self.coordinator.async_request_refresh()
+        # One settle window is all the pending value is for. If the refresh
+        # confirmed it, `_handle_coordinator_update` has already cleared it;
+        # if the grill did not take it, follow the grill rather than assert a
+        # value it will never report.
+        if self._pending_value is not None:
+            self._pending_value = None
+            self.async_write_ha_state()
 
     @property
     def native_min_value(self) -> float:

--- a/custom_components/pitboss/select.py
+++ b/custom_components/pitboss/select.py
@@ -9,12 +9,11 @@ from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_call_later
 
-from .const import DOMAIN
+from .const import DOMAIN, MCU_SETTLE_SECONDS
 from .coordinator import PitBossDataUpdateCoordinator
 from .entity import BaseEntity
 
 # The MCU is polled every couple of seconds; give it time to report back.
-MCU_SETTLE_SECONDS = 6
 
 UNIT_CELSIUS = UnitOfTemperature.CELSIUS
 UNIT_FAHRENHEIT = UnitOfTemperature.FAHRENHEIT

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -280,3 +280,74 @@ async def test_a_restored_target_the_grill_already_has_is_not_rewritten(
 
     mock_pitboss.set_probe_target.assert_not_awaited()
     assert coordinator.probe_target(2) == 190
+
+
+@pytest.mark.parametrize("model", ["PBV4PS2"])
+async def test_the_value_we_set_survives_a_stale_board_report(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+    mock_pitboss: Mock,
+) -> None:
+    """The board keeps reporting the previous target for a moment.
+
+    `probe_target` puts `pNTarget` first, so reading it straight back after a
+    set makes the slider snap to the old value. 15 of the 20 control boards
+    report `p1Target`, so this is the common path rather than an edge case.
+    """
+    entry = await mock_add_config_entry()
+    coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator.async_set_updated_data(
+        {"p1Target": 165, "p1Temp": 70, "isFahrenheit": True}
+    )
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        "number",
+        "set_value",
+        {"entity_id": "number.mygrill_mpc_target", "value": 180},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("number.mygrill_mpc_target")
+    assert state is not None
+    assert state.state == "180"
+
+    # Still the old value on the wire; the entity must not follow it back.
+    coordinator.async_set_updated_data(
+        {"p1Target": 165, "p1Temp": 70, "isFahrenheit": True}
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get("number.mygrill_mpc_target")
+    assert state is not None
+    assert state.state == "180"
+
+
+@pytest.mark.parametrize("model", ["PBV4PS2"])
+async def test_the_grill_wins_once_it_confirms(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+    mock_pitboss: Mock,
+) -> None:
+    """Once the board reports the new target, it is the board's value again."""
+    entry = await mock_add_config_entry()
+    coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator.async_set_updated_data({"p1Target": 165, "isFahrenheit": True})
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        "number",
+        "set_value",
+        {"entity_id": "number.mygrill_mpc_target", "value": 180},
+        blocking=True,
+    )
+    coordinator.async_set_updated_data({"p1Target": 180, "isFahrenheit": True})
+    await hass.async_block_till_done()
+
+    entity = get_entity(
+        hass, "number", "number.mygrill_mpc_target", TargetProbeTemperature
+    )
+    assert entity._pending_value is None
+    state = hass.states.get("number.mygrill_mpc_target")
+    assert state is not None
+    assert state.state == "180"


### PR DESCRIPTION
Setting a probe target makes the slider jump back to its previous value for up to a poll interval.

## Why

`coordinator.probe_target()` reads the board's own `pNTarget` first, which is right — a target set from the phone shows up immediately that way. But it is still the *previous* value for as long as it takes the board to report the new one, and `async_set_native_value` ends with `async_update_listeners()`, so the entity re-read the old target and rendered it.

Not an edge case. I checked the catalogue with comments stripped — a plain grep over `grills.json` says all 20 boards, but five have the line commented out — and **15 of the 20 boards report `p1Target` in live code**: LBL, LFS, PBA, PBB, PBD, PBE, PBL, PBL2, PBL3, PBP, PBT, PBV, PBV2, PBVA, PBX1. So this is what most grills do, on the control probe.

## The change

The same shape `select.py` already uses, which the grill's temperature unit needed for the same reason: show what we asked for, clear it as soon as the coordinator reports that value, and give up on it after one settle window if the grill never does. `MCU_SETTLE_SECONDS` moves to `const.py` now that it has two callers.

`ProbeTargetReachedSensor` deliberately still follows the coordinator rather than the pending value — it answers whether the grill has reached its target, which is a question about the grill, not about what we asked for.

## Testing

Two tests, both **verified to fail on the unpatched code** (restored `number.py` from `main`, kept the tests): the value survives a refresh that still carries the old `p1Target`, and the pending value is dropped once the board confirms.

127 pass, `ruff check`, `ruff format --check` and `mypy .` clean.

As on #360: the suite does not run on macOS — the `bluetooth` component fails to set up in `dbus_fast` — so I ran everything in a Linux container matching CI, and confirmed the baseline was green there first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)