### PR TITLE
Put a late firmware read on the device page too

### DIFF
--- a/custom_components/pitboss/__init__.py
+++ b/custom_components/pitboss/__init__.py
@@ -160,9 +160,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         await pitboss.stop()
         raise
 
-    if coordinator.firmware_version:
-        coordinator.device_info["sw_version"] = coordinator.firmware_version
-
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
 

--- a/custom_components/pitboss/coordinator.py
+++ b/custom_components/pitboss/coordinator.py
@@ -7,6 +7,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from pytboss.api import PitBoss
@@ -200,6 +201,26 @@ class PitBossDataUpdateCoordinator(DataUpdateCoordinator[StateDict]):
         except Exception as ex:  # noqa: BLE001
             # Cosmetic; never worth failing a refresh over.
             self.logger.debug("Could not fetch the firmware version: %s", ex)
+            return
+        if self.firmware_version:
+            self._async_publish_firmware_version()
+
+    def _async_publish_firmware_version(self) -> None:
+        """Put the version where the device page reads it from.
+
+        `device_info` covers the first read, which happens before the device
+        exists -- the registry entry is created from it when the platforms
+        are set up. A read that only succeeds later has to update the
+        registry itself, which is the whole point of retrying: the sensor
+        would populate while the device page stayed blank until a reload.
+        """
+        self.device_info["sw_version"] = self.firmware_version
+        registry = dr.async_get(self.hass)
+        device = registry.async_get_device(
+            identifiers=self.device_info.get("identifiers", set())
+        )
+        if device is not None:
+            registry.async_update_device(device.id, sw_version=self.firmware_version)
 
     def _merge_state(self, state: StateDict) -> StateDict:
         """Fold a state frame onto the last known one.

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -262,3 +262,38 @@ async def test_probes_keep_plain_numbering_without_mpc(
     await mock_add_config_entry()
     assert hass.states.get("sensor.mygrill_probe_1") is not None
     assert hass.states.get("sensor.mygrill_mpc") is None
+
+
+@pytest.mark.parametrize("model", ["PBV4PS2"])
+async def test_a_late_firmware_read_reaches_the_device_page(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+    mock_pitboss: Mock,
+) -> None:
+    """The retry populated the sensor but not the device registry.
+
+    `device_info` is only read when the device is created, so a version that
+    arrives after setup had nowhere to go: the sensor showed it while the
+    device page stayed blank until the integration was reloaded.
+    """
+    mock_pitboss.get_firmware_version.side_effect = RuntimeError("nope")
+    entry = await mock_add_config_entry()
+
+    registry = dr.async_get(hass)
+    device = registry.async_get_device(identifiers={(DOMAIN, "mygrill")})
+    assert device is not None
+    assert device.sw_version is None
+
+    mock_pitboss.get_firmware_version.side_effect = None
+    mock_pitboss.get_firmware_version.return_value = {"firmwareVersion": "0.5.7"}
+    coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    assert coordinator._firmware_attempted_at is not None
+    coordinator._firmware_attempted_at -= SYS_INFO_INTERVAL + 1
+    async_fire_time_changed(
+        hass, dt_util.utcnow() + STANDBY_SCAN_INTERVAL + timedelta(seconds=1)
+    )
+    await hass.async_block_till_done()
+
+    device = registry.async_get_device(identifiers={(DOMAIN, "mygrill")})
+    assert device is not None
+    assert device.sw_version == "0.5.7"


### PR DESCRIPTION
`_async_refresh_firmware_version` exists because the read at setup used to be the only attempt — its docstring says it: *"a grill that failed to answer it once had no firmware sensor until the integration was reloaded"*.

But the device registry is still written exactly once, in `async_setup_entry`:

```python
if coordinator.firmware_version:
    coordinator.device_info["sw_version"] = coordinator.firmware_version
```

and `device_info` is only read when the device is created. So half the fix landed: when a retry finally succeeds, the sensor populates and the **device page stays blank forever** — for exactly the grill the retry was added for.

## The change

The coordinator publishes it now, in the one place that knows when it arrived. `device_info` still covers the first read, which happens before the device exists (the registry entry is created from it during platform setup); a read that only succeeds later updates the registry directly. The one-shot write in `async_setup_entry` goes, since it was the same thing done in one of the two cases.

## Testing

A new test drives the same path the existing recovery test does — first read fails, a later one succeeds — and asserts the registry, not the sensor. **It fails on the unpatched code**, where `device.sw_version` stays `None`.

127 pass, `ruff check`, `ruff format --check` and `mypy .` clean, run in a Linux container as on #360 (the suite does not start on macOS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)