### PR TITLE
Stop retrying two failures that retrying cannot fix

### DIFF
--- a/custom_components/pitboss/__init__.py
+++ b/custom_components/pitboss/__init__.py
@@ -19,7 +19,7 @@ from homeassistant.const import (
     Platform,
 )
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.exceptions import ConfigEntryError, ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.typing import ConfigType
@@ -135,6 +135,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             control_board,
         )
         control_board = None
+        try:
+            await hass.async_add_executor_job(grills.get_grill, model, None)
+        except InvalidGrill as ex:
+            # Not "not ready": `api.start()` would raise this again on every
+            # retry, and no amount of waiting introduces a model to the
+            # catalogue. Asking the user to reconfigure is the only way out.
+            raise ConfigEntryError(f"Unknown grill model: {model}") from ex
 
     # Constructed inline: since spec resolution moved into `start()`, the
     # constructor only assigns attributes. The executor job it ran in was a

--- a/custom_components/pitboss/services.py
+++ b/custom_components/pitboss/services.py
@@ -9,6 +9,7 @@ from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import device_registry as dr
+from pytboss.exceptions import Unauthorized
 
 from .const import DOMAIN, LOGGER
 from .coordinator import PitBossDataUpdateCoordinator
@@ -55,6 +56,16 @@ async def _async_set_grill_password(hass: HomeAssistant, call: ServiceCall) -> N
 
     try:
         await coordinator.api.set_grill_password(new_password)
+    except Unauthorized as ex:
+        # Changing the password is authenticated with the current one, so
+        # this means the one Home Assistant holds is not the grill's. That is
+        # the same condition the coordinator opens a reauth flow for, and it
+        # is the only thing that lets the user fix it.
+        entry.async_start_reauth(hass)
+        raise HomeAssistantError(
+            "The grill rejected the password Home Assistant holds. "
+            "Enter the current one and try again."
+        ) from ex
     except Exception as ex:
         raise HomeAssistantError(f"Could not set the grill password: {ex}") from ex
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -319,3 +319,31 @@ async def test_a_partial_frame_does_not_change_the_interval(
     await coordinator._on_state_update({"grillTemp": 105})
 
     assert coordinator.update_interval == ACTIVE_SCAN_INTERVAL
+
+
+async def test_setup_fails_permanently_for_a_model_not_in_the_catalogue(
+    hass: HomeAssistant,
+    model: str,
+) -> None:
+    """Retrying cannot introduce a model to the catalogue.
+
+    The fallback to resolving by name alone is for entries whose prefix and
+    model do not pair. When that fails too the model itself is unknown, and
+    `api.start()` would raise the same thing on every retry -- so the entry
+    has to stop and ask, rather than back off forever.
+    """
+    entry = MockConfigEntry(
+        title="title",
+        domain=DOMAIN,
+        data={
+            CONF_DEVICE_ID: "mygrill",
+            CONF_MODEL: "NO-SUCH-MODEL",
+            CONF_PASSWORD: "asdfasdf",
+            CONF_PROTOCOL: PROTOCOL_WSS,
+        },
+    )
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.SETUP_ERROR

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -6,6 +6,7 @@ from homeassistant.const import CONF_PASSWORD
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import device_registry as dr
+from pytboss.exceptions import Unauthorized
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.pitboss.const import DOMAIN
@@ -106,3 +107,32 @@ async def test_a_failed_change_leaves_the_entry_alone(
             blocking=True,
         )
     assert entry.data[CONF_PASSWORD] == "asdfasdf"
+
+
+async def test_a_rejected_password_offers_reauth(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+    mock_pitboss: Mock,
+) -> None:
+    """Changing the password is authenticated with the current one.
+
+    So a rejection means the one Home Assistant holds is not the grill's,
+    which is the condition the coordinator opens a reauth flow for. Without
+    one the user gets an error toast and no way to correct it.
+    """
+    entry = await mock_add_config_entry()
+    mock_pitboss.is_connected.return_value = True
+    mock_pitboss.set_grill_password.side_effect = Unauthorized("Unauthorized", 401)
+
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            DOMAIN,
+            "set_grill_password",
+            {"device_id": _device_id(hass), CONF_PASSWORD: "hunter2"},
+            blocking=True,
+        )
+    await hass.async_block_till_done()
+
+    assert entry.data[CONF_PASSWORD] == "asdfasdf"
+    flows = hass.config_entries.flow.async_progress_by_handler(DOMAIN)
+    assert [f for f in flows if f["context"].get("source") == "reauth"]


### PR DESCRIPTION
Two failures present as transient and are not. Both need the user, and neither gets to them today.

## An unknown model retries forever

Setup resolves the grill with the advertised prefix as its control board, and falls back to resolving by name alone when that pair does not exist — for entries the old board-remap workarounds left behind. But the fallback is never validated. If the model itself is not in the catalogue (a renamed entry after a definitions refresh, a hand-edited entry), `api.start()` raises `InvalidGrill` from inside the coordinator, where Home Assistant logs *"Unexpected error fetching pitboss data"* with a traceback and turns it into `ConfigEntryNotReady` — an escalating backoff, forever, for something no amount of waiting resolves.

The fallback is checked now, and a model that resolves neither way raises `ConfigEntryError`.

## A rejected password gives a toast and no way out

`set_grill_password` authenticates with the *current* password, so `Unauthorized` there means the one Home Assistant holds is not the grill's. That is precisely the condition the coordinator turns into `ConfigEntryAuthFailed` and a reauth flow — but the service wraps every exception into `HomeAssistantError`, so the user sees a flat error and is left to guess.

It now starts the reauth flow and says what happened. The entry is still left alone, as before.

## Testing

Two tests, both **verified to fail on the unpatched code**: an entry whose model is not in the catalogue ends in `SETUP_ERROR` rather than `SETUP_RETRY`, and a rejected password leaves a reauth flow in progress.

128 pass, `ruff check`, `ruff format --check` and `mypy .` clean, run in a Linux container as on #360 and #362.

🤖 Generated with [Claude Code](https://claude.com/claude-code)