### PR TITLE
Back off, and say why, when a cycle fails

### DIFF
--- a/custom_components/pitboss/coordinator.py
+++ b/custom_components/pitboss/coordinator.py
@@ -286,6 +286,20 @@ class PitBossDataUpdateCoordinator(DataUpdateCoordinator[StateDict]):
             self.logger.debug("Could not fetch the system info: %s", ex)
 
     async def _async_update_data(self) -> StateDict:
+        try:
+            return await self._async_poll()
+        except UpdateFailed:
+            # Back off before giving up on this cycle. The interval is
+            # otherwise whatever the last *successful* read set, so a grill
+            # that goes off while the connection stays up -- which is the
+            # normal case on the cloud relay, where the socket outlives the
+            # grill -- keeps a ten-second ping in flight for as long as it
+            # is off, which is the opposite of what the two intervals exist
+            # for.
+            self._apply_poll_interval(StateDict())
+            raise
+
+    async def _async_poll(self) -> StateDict:
         if not self._api_started:
             self.logger.debug("Starting API")
             await self._start_api()
@@ -297,6 +311,12 @@ class PitBossDataUpdateCoordinator(DataUpdateCoordinator[StateDict]):
             await self.api.ping(timeout=10.0)
         except NotConnectedError as ex:
             raise UpdateFailed("Grill not connected") from ex
+        except TimeoutError as ex:
+            # `send_command` raises this when a reply does not arrive, which
+            # is the ordinary outcome for a grill that is off behind a socket
+            # that is still open. Uncaught it reaches Home Assistant's generic
+            # handler, which reports "Timeout fetching pitboss data" instead.
+            raise UpdateFailed("Grill did not answer") from ex
 
         await self._async_refresh_sys_info()
         await self._async_refresh_firmware_version()
@@ -311,6 +331,8 @@ class PitBossDataUpdateCoordinator(DataUpdateCoordinator[StateDict]):
             return state
         except NotConnectedError as ex:
             raise UpdateFailed("Grill not connected") from ex
+        except TimeoutError as ex:
+            raise UpdateFailed("Grill did not answer") from ex
         except Unauthorized as ex:
             # The grill rejected the password rather than failing the call.
             # Retrying cannot fix that, and on a transport where `PB.GetState`

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -7,6 +7,10 @@ from homeassistant.helpers.update_coordinator import UpdateFailed
 from pytboss.exceptions import GrillUnavailable, NotConnectedError, RPCError
 from pytboss.grills import StateDict
 
+from custom_components.pitboss.const import (
+    ACTIVE_SCAN_INTERVAL,
+    STANDBY_SCAN_INTERVAL,
+)
 from custom_components.pitboss.coordinator import PitBossDataUpdateCoordinator
 
 pytestmark = pytest.mark.parametrize("model", ["PBV4PS2"])
@@ -150,3 +154,41 @@ async def test_on_state_update_merges_onto_previous_data(
 
     await coordinator._on_state_update({"moduleIsOn": False})
     assert coordinator.data == {"grillTemp": 225, "moduleIsOn": False}
+
+
+async def test_a_ping_timeout_is_reported_as_a_failed_update(
+    coordinator: PitBossDataUpdateCoordinator, mock_pitboss: Mock
+) -> None:
+    """`send_command` raises `TimeoutError` when no reply arrives.
+
+    That is the ordinary outcome for a grill that is off behind a socket
+    which is still open, so it must not reach Home Assistant's generic
+    handler as an unexpected error.
+    """
+    coordinator._api_started = True
+    mock_pitboss.is_connected.return_value = True
+    mock_pitboss.ping.side_effect = TimeoutError()
+
+    with pytest.raises(UpdateFailed):
+        await coordinator._async_update_data()
+
+
+async def test_a_failed_cycle_backs_the_poll_interval_off(
+    coordinator: PitBossDataUpdateCoordinator, mock_pitboss: Mock
+) -> None:
+    """The interval was otherwise whatever the last success set.
+
+    On the cloud relay the socket outlives the grill, so a grill switched
+    off keeps failing at the active cadence -- a ten-second ping in flight
+    for as long as it is off.
+    """
+    coordinator._api_started = True
+    mock_pitboss.is_connected.return_value = True
+    coordinator._apply_poll_interval(StateDict(moduleIsOn=True))
+    assert coordinator.update_interval == ACTIVE_SCAN_INTERVAL
+
+    mock_pitboss.ping.side_effect = TimeoutError()
+    with pytest.raises(UpdateFailed):
+        await coordinator._async_update_data()
+
+    assert coordinator.update_interval == STANDBY_SCAN_INTERVAL


### PR DESCRIPTION
A grill that is switched off while its connection stays up — the normal case on the cloud relay, where the socket outlives the grill — keeps polling at the active cadence and reports the wrong reason for it. Two halves of the same cycle.

## The interval never backs off after a failure

`_apply_poll_interval` runs only after a successful `get_state`. Any earlier failure returns first, so `update_interval` stays at whatever the last **successful** read set.

So: grill lit → `ACTIVE_SCAN_INTERVAL` (10 s). User switches it off. `api.is_connected()` is still true, because the relay socket is still open — the `ConnectivitySensor` docstring already describes exactly this. Every cycle now reaches `api.ping(timeout=10.0)` and burns the full ten seconds timing out, and the interval never reaches `STANDBY_SCAN_INTERVAL`. A ten-second ping permanently in flight for as long as the grill is off, which is the opposite of what the two constants exist for.

Backing off on failure is now in one place: `_async_update_data` wraps the cycle, and the body moves to `_async_poll`.

## `TimeoutError` is not caught, and it is the likely one

`Transport.send_command` raises `TimeoutError` when a reply does not arrive — which is precisely what happens above. Only `NotConnectedError` was caught, at both the `ping` and the `get_state` call sites, so the timeout reached Home Assistant's generic handler and the entry's failure reason became *"Timeout fetching pitboss data"* instead of the intended `UpdateFailed`.

Both sites now treat it as a failed cycle with a reason that says what happened.

## Testing

Two tests, both **verified to fail on the unpatched code**: a ping timeout surfaces as `UpdateFailed`, and a failed cycle leaves the interval at standby rather than active.

133 pass, `ruff check`, `ruff format --check` and `mypy .` clean, run in a Linux container as on #360, #362 and #363 — the suite does not start on macOS, where setting up the `bluetooth` component dies in `dbus_fast`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
