### PR TITLE
Bump pytboss to 2026.8.4

### DIFF
--- a/custom_components/pitboss/manifest.json
+++ b/custom_components/pitboss/manifest.json
@@ -77,7 +77,7 @@
     "pytboss"
   ],
   "requirements": [
-    "pytboss==2026.8.3"
+    "pytboss==2026.8.4"
   ],
   "version": "0000.0.0"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ mypy==2.3.0
 pip>=26.2
 pyserial-asyncio==0.6
 pyserial==3.5
-pytboss==2026.8.3
+pytboss==2026.8.4
 pytest_homeassistant_custom_component==0.13.348
 ruff==0.16.1
 serialx==1.8.2


### PR DESCRIPTION
Bumps both pins, which serve different readers: `requirements.txt` is what CI installs, `custom_components/pitboss/manifest.json` is what a user's Home Assistant resolves. `docs/SUPPORTED_GRILLS.md` is untouched.

2026.8.4 is the first release carrying the local HTTP transport (dknowles2/pytboss#543) and `turn_grill_on()` (dknowles2/pytboss#550), so it is the release both held branches were waiting on — @trailro's `feat/local-transport` for #344 and `feat/start-grill` for #322 can be raised against this.

## Verified

`2026.8.4` is live on PyPI, installed into the local venv, and `mypy custom_components/pitboss` is clean against it — 14 source files, no issues. That is the check that matters here, since the risk in a pin bump is the library's type surface moving underneath the integration, and this release carries the `RPCResult` widening.

**The test suite is not a signal locally** and I am not presenting it as one. It fails identically on unmodified `main` — 116 failed, 17 passed, `KeyError: 'pitboss'` — so I ran `main` as a control rather than reading the failures as caused by this change. CI is the real check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)