### PR TITLE
Bring the README up to date, and make that part of the work

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,45 @@ merge in order — a PR that reads a new attribute is blocked on the release
 *and* on the bump landing first, and neither CI nor GitHub can express that.
 Say so in the PR.
 
+## Update the docs in the PR that changes the behaviour
+
+`README.md` is what users read to decide whether this integration does what
+they want. It is part of the change, not follow-up work — a PR that adds an
+entity and leaves the README alone is incomplete, and the gap is invisible in
+review because nothing fails.
+
+Update it in the same PR when a change:
+
+- **adds, removes or renames an entity**, or changes when one is created —
+  the platform table and the entity list both name specific entities;
+- **adds a platform** — the table lists platforms, and `PLATFORMS` in
+  `__init__.py` is the list to check it against;
+- **adds or changes an action** — see the Actions section;
+- **changes what a user sees or has to do**: setup and reconfigure steps,
+  repair flows, a new option, polling behaviour they would notice;
+- **changes something the README states as a fact** — connection protocols,
+  what is and is not local, or the safety position on remote start.
+
+Two things to check rather than assume:
+
+```sh
+# Every platform the integration actually sets up.
+grep -A 12 'PLATFORMS: list\[Platform\]' custom_components/pitboss/__init__.py
+# Every entity name a user will see.
+grep -rn '_attr_name' custom_components/pitboss/
+```
+
+The README drifted a whole release behind once — it described probe targets
+as existing for probes 1 and 2 only, listed six platforms when eight were
+registered, and called the `wss` protocol "local WiFi" when it connects
+outbound to `socket.dansonscorp.com`. Each of those was correct when written,
+and none of them failed a test.
+
+`CONTRIBUTING.md` and `REVIEW.md` change far less often; touch them when the
+workflow or the repo boundary genuinely moves, not routinely.
+
+`docs/SUPPORTED_GRILLS.md` is generated — see below.
+
 ## Gotchas
 
 - **Generated files — don't hand-edit**:

--- a/README.md
+++ b/README.md
@@ -21,34 +21,57 @@ dependency is updated.
 
 ## Features
 
-- **100% local, no cloud required.** Communicates directly with the grill over Bluetooth (BLE) or your local WiFi (WebSocket), reported to Home Assistant as a `local_push` integration.
+- **No account, no app.** The integration talks to the grill itself. It never signs in to a PitBoss account and never uses the vendor's mobile app.
 - **Automatic discovery.** Power on your grill and it's discovered automatically over Bluetooth; manual setup by device ID is also supported.
-- **Dual connection protocols.** Choose Bluetooth (`ble`) or WebSocket (`wss`, default) when configuring the integration, and switch between them later via reconfigure.
-- **Reconfigurable.** Change the grill model, password, or connection protocol after initial setup without deleting the integration.
-- **Adapts to your grill's capabilities.** Entities such as the grill light, meat probes, primer motor switch, and recipe sensors are only created if your specific model supports them.
-- **Safety first.** For safety reasons, the integration can never turn the grill on remotely — you can only monitor it and turn it off. This mirrors the physical safety design of the grill itself.
+- **Two connection protocols.** Bluetooth (`ble`) or WebSocket (`wss`, the default), chosen at setup and changeable later via reconfigure. See [Connection protocols](#connection-protocols) — they are not equivalent, and one of them is not local.
+- **Reconfigurable, and it asks rather than gives up.** Change the model, password, or protocol without deleting the integration. If the grill starts rejecting the password, the integration asks you to re-enter it instead of retrying forever.
+- **Adapts to your grill.** The light, primer motor, recipe sensors, probe count, probe naming, and per-probe targets are all created from what your model and control board declare — not assumed.
+- **Polls faster when it matters.** Updates arrive quickly while the grill is running and back off in standby.
+- **Safety first.** The integration cannot turn the grill on remotely. You can monitor it and turn it off.
+
+### Connection protocols
+
+| | Reaches the grill via | Needs internet |
+| --- | --- | --- |
+| `ble` | Bluetooth, directly | No |
+| `wss` (default) | `socket.dansonscorp.com`, the vendor's relay | **Yes** |
+
+**`wss` is not a local connection.** Despite being described as "WiFi", it connects outbound to Dansons' servers, which relay to your grill. It is the default because it is the more reliable of the two — Bluetooth range and adapter quirks cause most connection problems — but if you want no cloud in the path, choose `ble`.
+
+A genuinely local option exists in the grill's firmware and is being added to [pytboss](https://github.com/dknowles2/pytboss); it is not wired up here yet, and it does not work on every grill.
 
 **This integration will set up the following platforms:**
 
-| Platform        | Description                                                                                                    |
-| ---------------- | --------------------------------------------------------------------------------------------------------------- |
-| `binary_sensor`  | Diagnostic error sensors (probe/startup/high-temp/fan/igniter/auger/pellet errors) and an auger "running" sensor |
-| `climate`        | Monitors and controls grill temperature; reports heating/cooling/fan/idle status; turn off only (safety)         |
-| `light`          | Controls the grill's built-in light, if the model has one                                                        |
-| `number`         | Sets target temperatures for meat probes 1 and 2, on models that support probe-based shutoff/alerts              |
-| `sensor`         | Meat probe temperatures (up to 4 probes, enabled based on how many the grill has), and recipe time/step for models with guided-recipe functionality |
-| `switch`         | Grill module power (turn off only, for safety) and primer motor control, if supported by the model               |
+| Platform | Description |
+| --- | --- |
+| `binary_sensor` | Error flags, live fan/igniter/auger state, connectivity, per-probe "target reached", and whether the grill has a meat probe control port |
+| `button` | Restart the controller; request fast updates |
+| `climate` | Grill temperature and HVAC action; turn off only (safety) |
+| `light` | The grill's built-in light, if the model has one |
+| `number` | A target temperature for every probe the grill supports |
+| `select` | The temperature unit the grill itself displays |
+| `sensor` | Probe temperatures, recipe progress, firmware version, controller uptime and free memory |
+| `switch` | Grill module power (turn off only) and the primer motor |
 
 ### Entity details
 
-- **Climate (`Grill temperature`):** Shows current and target grill temperature, and HVAC action (heating/cooling/fan/idle/off). Setting HVAC mode to `off` turns off the grill and resets the target temperature to the model's minimum. The grill cannot be turned on remotely for safety reasons.
-- **Light (`Light`):** On/off control for the grill's light, only created for models that have one.
-- **Sensor (`Probe 1`–`Probe 4`):** Meat probe temperatures in °F or °C, matching the grill's current unit setting. Only as many probes as the grill physically supports are enabled by default.
-- **Sensor (`Recipe Time` / `Recipe Step`):** Progress through a guided recipe, for models with recipe functionality.
-- **Number (`Probe 1 Target` / `Probe 2 Target`):** Set a target temperature for probes 1 and 2, on models that support it.
-- **Switch (`Module power`):** Turns the grill module off (cannot turn it on remotely, for safety).
+- **Climate (`Grill temperature`):** Current and target temperature, plus HVAC action. Target temperatures snap to the values the control board actually accepts — the board silently ignores anything else. Setting HVAC mode to `off` turns the grill off and leaves the setpoint alone.
+- **Sensor (`MPC`/`P2`–`P4`, or `Probe 1`–`Probe 4`):** Probe temperatures in the grill's current unit. On grills with a meat probe control port, probe 1 is labelled `MPC` to match what is printed by the socket; other grills keep numbered names. Only as many probes as the grill has are enabled.
+- **Number (`… target`):** A target for every probe the board supports, not just the first two. Targets can be set while the probe is unplugged and while the grill is off — they are held and sent when the grill comes on.
+- **Binary sensor (`… target reached`):** One per probe, comparing the probe against its target.
+- **Binary sensor (`Connectivity`):** Stays available so it can report *disconnected*, rather than vanishing along with everything else.
+- **Binary sensor (`Meat probe control`):** Whether the grill has a control port at all.
+- **Binary sensor (errors and state):** Probe, startup, high-temperature, fan, igniter, auger and no-pellets errors, plus live fan, igniter and auger state.
+- **Select (`Grill temperature unit`):** Switches the unit the *grill's own panel* uses. This does not change how Home Assistant displays temperatures — that follows your Home Assistant unit system.
+- **Button (`Restart controller`):** Restarts the WiFi controller, the usual fix when it stops responding.
+- **Button (`Request fast updates`):** Asks the grill to push status every 5 seconds for the next 5 minutes. Does nothing unless the grill is on, and nothing on any path but the relay (`wss`) one, since that is where those pushes go.
+- **Sensor (`Firmware version`, `Controller uptime`, `Controller free memory`):** Diagnostics, read on a slower cadence than grill state.
+- **Switch (`Module power`):** Turns the grill off. Stays available and reports `off` when the grill is off, rather than disappearing.
 - **Switch (`Prime`):** Runs the auger primer motor, on models that support it.
-- **Binary sensor:** Diagnostic error flags (probe errors, startup error, high-temperature error, fan error, igniter error, auger error, no-pellets) plus an `Auger` running-state sensor.
+
+### Actions
+
+- **`pitboss.set_grill_password`:** Sets the grill's connection password and stores it in the config entry, so the two cannot drift apart.
 
 ## Installation
 
@@ -72,14 +95,18 @@ as the category.
 
 Power on your grill and it should be discovered automatically over Bluetooth. Once you
 initiate the setup process, it will ask for your exact grill model so we can properly
-communicate with it. No cloud access necessary!
+communicate with it. No PitBoss account is needed either way.
 
 If your grill isn't discovered automatically, you can add it manually by entering its
 device ID. You'll then choose your exact model and, optionally, a connection password
-and whether to connect over Bluetooth or WebSocket (WiFi).
+and whether to connect over Bluetooth (`ble`) or the vendor relay (`wss`) — see
+[Connection protocols](#connection-protocols) for what that choice means.
 
 Already set up? You can change the model, password, or connection protocol at any time
 via the integration's "Reconfigure" option, without needing to remove and re-add it.
+
+If the grill starts rejecting your password, the integration starts a reauthentication
+flow asking you to enter it again, rather than retrying indefinitely.
 
 ## Contributions are welcome!
 


### PR DESCRIPTION
Docs only. No code changes.

## What was stale

The README described the integration as it was a release ago. It listed **six platforms where eight are registered**, said probe targets existed for **probes 1 and 2** when #341 gave every probe one, and never mentioned buttons, the grill-unit select, the connectivity sensor, target-reached sensors, the meat probe control sensor, firmware and controller diagnostics, adaptive polling, reauth, or the `set_grill_password` action.

## What was wrong

Different problem, and worth separating out. The Features list opened with:

> **100% local, no cloud required.** Communicates directly with the grill over Bluetooth (BLE) or your local WiFi (WebSocket)

`wss` is not local WiFi. It connects outbound to `socket.dansonscorp.com` and the vendor relays to the grill — and `DEFAULT_PROTOCOL = PROTOCOL_WSS`, so that is what most installs are doing. The page told users the opposite of what the default does, in bold, as its headline feature. "No cloud access necessary!" appeared again lower down.

There is now a table saying plainly which protocol reaches the grill how and which needs internet, with `ble` named as the option for people who want no cloud in the path. The genuinely local transport is described as what it is: coming to pytboss, not wired up here, and not available on every grill.

## Checked against the code, not the release notes

- platform list ← `PLATFORMS` in `__init__.py` (8, and the table now has 8)
- entity names ← `_attr_name` across `custom_components/pitboss/`
- probe labelling ← `probe_label()`, which follows the vendor app: `MPC` only on grills with a control port, and the numbering does not shift
- "request fast updates" ← `button.py`, which says it does nothing unless the grill is on and nothing off the cloud path — so the README says that too, rather than "a burst of frequent updates"
- setpoint snapping, held probe targets, switches staying available ← `coordinator.py`

## The AGENTS.md half

Adding the missing entities fixes today. The reason it drifted is that nothing asks for the README when an entity is added, and nothing fails when it is skipped — **every stale claim above was correct when it was written**.

So `AGENTS.md` now names updating `README.md` as part of the change rather than follow-up, lists the five kinds of change that require it, and gives the two greps that answer "did I miss an entity":

```sh
grep -A 12 'PLATFORMS: list\[Platform\]' custom_components/pitboss/__init__.py
grep -rn '_attr_name' custom_components/pitboss/
```

It also records the three specific drifts above, since a rule with the failure attached tends to survive better than a rule on its own.

## Verified

`ruff check .` and `mypy .` clean.

**The test suite is not a signal here and I am not presenting it as one** — it fails identically on unmodified `main` (116 failed, 17 passed, `KeyError: 'pitboss'`). This changes no code, so CI is the check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)