### PR TITLE
Call the connection choice Bluetooth and Cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,22 +23,26 @@ dependency is updated.
 
 - **No account, no app.** The integration talks to the grill itself. It never signs in to a PitBoss account and never uses the vendor's mobile app.
 - **Automatic discovery.** Power on your grill and it's discovered automatically over Bluetooth; manual setup by device ID is also supported.
-- **Two connection protocols.** Bluetooth (`ble`) or WebSocket (`wss`, the default), chosen at setup and changeable later via reconfigure. See [Connection protocols](#connection-protocols) — they are not equivalent, and one of them is not local.
+- **Two ways to connect.** **Bluetooth** or **Cloud** (the default), chosen at setup and changeable later via reconfigure. See [How it connects](#how-it-connects) — they are not equivalent, and one of them is not local.
 - **Reconfigurable, and it asks rather than gives up.** Change the model, password, or protocol without deleting the integration. If the grill starts rejecting the password, the integration asks you to re-enter it instead of retrying forever.
 - **Adapts to your grill.** The light, primer motor, recipe sensors, probe count, probe naming, and per-probe targets are all created from what your model and control board declare — not assumed.
 - **Polls faster when it matters.** Updates arrive quickly while the grill is running and back off in standby.
 - **Safety first.** The integration cannot turn the grill on remotely. You can monitor it and turn it off.
 
-### Connection protocols
+### How it connects
 
-| | Reaches the grill via | Needs internet |
+| Setting | Reaches the grill via | Needs internet |
 | --- | --- | --- |
-| `ble` | Bluetooth, directly | No |
-| `wss` (default) | `socket.dansonscorp.com`, the vendor's relay | **Yes** |
+| **Bluetooth** | Bluetooth, directly | No |
+| **Cloud** (default) | `socket.dansonscorp.com`, PitBoss's servers | **Yes** |
 
-**`wss` is not a local connection.** Despite being described as "WiFi", it connects outbound to Dansons' servers, which relay to your grill. It is the default because it is the more reliable of the two — Bluetooth range and adapter quirks cause most connection problems — but if you want no cloud in the path, choose `ble`.
+**Cloud is not a local connection**, despite reaching the grill over your WiFi. Your grill connects outbound to PitBoss's servers and Home Assistant talks to it through them. It is the default because it is the more reliable of the two — Bluetooth range and adapter quirks cause most connection problems — but if you want nothing in the path, choose Bluetooth.
+
+Neither option signs in to a PitBoss account, and no grill data is sent anywhere Home Assistant chooses; Cloud uses the same relay the grill already talks to on its own.
 
 A genuinely local option exists in the grill's firmware and is being added to [pytboss](https://github.com/dknowles2/pytboss); it is not wired up here yet, and it does not work on every grill.
+
+(In diagnostics and stored configuration these still appear as `ble` and `wss`, which is what the grill protocol calls them.)
 
 **This integration will set up the following platforms:**
 
@@ -64,7 +68,7 @@ A genuinely local option exists in the grill's firmware and is being added to [p
 - **Binary sensor (errors and state):** Probe, startup, high-temperature, fan, igniter, auger and no-pellets errors, plus live fan, igniter and auger state.
 - **Select (`Grill temperature unit`):** Switches the unit the *grill's own panel* uses. This does not change how Home Assistant displays temperatures — that follows your Home Assistant unit system.
 - **Button (`Restart controller`):** Restarts the WiFi controller, the usual fix when it stops responding.
-- **Button (`Request fast updates`):** Asks the grill to push status every 5 seconds for the next 5 minutes. Does nothing unless the grill is on, and nothing on any path but the relay (`wss`) one, since that is where those pushes go.
+- **Button (`Request fast updates`):** Asks the grill to push status every 5 seconds for the next 5 minutes. Does nothing unless the grill is on, and nothing unless you are connected via Cloud, since that is where those pushes go.
 - **Sensor (`Firmware version`, `Controller uptime`, `Controller free memory`):** Diagnostics, read on a slower cadence than grill state.
 - **Switch (`Module power`):** Turns the grill off. Stays available and reports `off` when the grill is off, rather than disappearing.
 - **Switch (`Prime`):** Runs the auger primer motor, on models that support it.
@@ -99,8 +103,8 @@ communicate with it. No PitBoss account is needed either way.
 
 If your grill isn't discovered automatically, you can add it manually by entering its
 device ID. You'll then choose your exact model and, optionally, a connection password
-and whether to connect over Bluetooth (`ble`) or the vendor relay (`wss`) — see
-[Connection protocols](#connection-protocols) for what that choice means.
+and whether to connect over **Bluetooth** or the **Cloud** — see
+[How it connects](#how-it-connects) for what that choice means.
 
 Already set up? You can change the model, password, or connection protocol at any time
 via the integration's "Reconfigure" option, without needing to remove and re-add it.

--- a/custom_components/pitboss/translations/en.json
+++ b/custom_components/pitboss/translations/en.json
@@ -22,12 +22,12 @@
         "data": {
           "model": "Model",
           "password": "Grill password",
-          "protocol": "Connection protocol"
+          "protocol": "Connection"
         },
         "data_description": {
           "model": "The model is needed to properly communicate with your grill",
           "password": "The password for your grill, NOT your PitBoss account",
-          "protocol": "The protocol to use to connect to your grill."
+          "protocol": "Bluetooth talks to the grill directly. Cloud connects through PitBoss's servers, so it needs internet, but it is not limited by Bluetooth range."
         }
       },
       "reconfigure": {
@@ -35,12 +35,12 @@
         "data": {
           "model": "Model",
           "password": "Grill password",
-          "protocol": "Connection protocol"
+          "protocol": "Connection"
         },
         "data_description": {
           "model": "The model is needed to properly communicate with your grill",
           "password": "The password for your grill, NOT your PitBoss account",
-          "protocol": "The protocol to use to connect to your grill."
+          "protocol": "Bluetooth talks to the grill directly. Cloud connects through PitBoss's servers, so it needs internet, but it is not limited by Bluetooth range."
         }
       },
       "reauth_confirm": {
@@ -55,8 +55,8 @@
   "selector": {
     "protocol": {
       "options": {
-        "ble": "Bluetooth (local)",
-        "wss": "WebSocket (cloud)"
+        "ble": "Bluetooth",
+        "wss": "Cloud"
       }
     }
   },


### PR DESCRIPTION
Re-raising the connection rename. It was pushed to #368 but that PR merged at the commit before it, so the change never landed — `main` still shows the old labels. Same commit, no changes.

## What changes

The picker offers **"Bluetooth (local)"** and **"WebSocket (cloud)"**. It will offer **"Bluetooth"** and **"Cloud"**.

"WebSocket" is a transport protocol, not a thing anyone is choosing between — the parenthetical was doing all the work, so it becomes the label.

The field is **"Connection"** rather than "Connection protocol", and its hint says what the choice does instead of restating the field name:

> ~~The protocol to use to connect to your grill.~~
> Bluetooth talks to the grill directly. Cloud connects through PitBoss's servers, so it needs internet, but it is not limited by Bluetooth range.

That second half is the trade someone is actually making, and it is why the cloud option is the default.

## Labels only

**The stored values stay `ble` and `wss`.** `PROTOCOL_BLE` and `PROTOCOL_WSS` are untouched, so no config entry changes and nothing needs migrating. The selector already went through `translation_key="protocol"`, so the whole functional change is `translations/en.json` — six lines.

The README section is renamed to match and notes that diagnostics and stored configuration still show `ble`/`wss`, so someone reading a diagnostics dump can tell it is the same thing.

`pt.json` has no `selector` section, so Portuguese falls back to English as it already did. I have not added a translation I cannot check.

## Verified

```
labels:          {'ble': 'Bluetooth', 'wss': 'Cloud'}
keys unchanged:  True
```

`ruff check .` and `mypy .` clean. No Python changes, so CI is the check for the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)