### PR TITLE
Add a start_grill action behind an opt-in

### DIFF
--- a/custom_components/pitboss/__init__.py
+++ b/custom_components/pitboss/__init__.py
@@ -168,7 +168,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         raise
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    entry.async_on_unload(entry.add_update_listener(_async_options_updated))
     return True
+
+
+async def _async_options_updated(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Reload when the options change.
+
+    The remote-start toggle is read live, so this is not strictly needed for
+    it -- but an options flow without a listener is a trap for the next
+    option added, and Home Assistant fixes some entity properties (a display
+    unit, for one) when the entity is registered.
+    """
+    await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/pitboss/climate.py
+++ b/custom_components/pitboss/climate.py
@@ -129,7 +129,8 @@ class GrillClimate(BaseEntity, ClimateEntity):
             await self.async_turn_off()
         elif hvac_mode == HVACMode.HEAT:
             LOGGER.warning(
-                "For safety reasons, the grill cannot be turned on remotely."
+                "Not lighting the grill from here. Use the pitboss.start_grill "
+                "action, which has to be enabled in the integration options first."
             )
 
     @property

--- a/custom_components/pitboss/config_flow.py
+++ b/custom_components/pitboss/config_flow.py
@@ -7,7 +7,12 @@ from typing import Any
 
 import voluptuous as vol
 from homeassistant.components.bluetooth import BluetoothServiceInfoBleak
-from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.config_entries import (
+    ConfigEntry,
+    ConfigFlow,
+    ConfigFlowResult,
+    OptionsFlow,
+)
 from homeassistant.const import CONF_DEVICE_ID, CONF_MODEL, CONF_PASSWORD, CONF_PROTOCOL
 from homeassistant.helpers.selector import SelectSelector, SelectSelectorConfig
 from pytboss import grills
@@ -25,6 +30,11 @@ def _models_on_board(control_board: str) -> list[str]:
 
 class PitBossFlowHandler(ConfigFlow, domain=DOMAIN):
     """Config flow for PitBoss."""
+
+    @staticmethod
+    def async_get_options_flow(config_entry: ConfigEntry) -> PitBossOptionsFlow:
+        """Return the options flow handler."""
+        return PitBossOptionsFlow()
 
     VERSION = 1
     MINOR_VERSION = 3
@@ -173,3 +183,34 @@ class PitBossFlowHandler(ConfigFlow, domain=DOMAIN):
         password = reconfigure_entry.data.get(CONF_PASSWORD, "")
         protocol = reconfigure_entry.data.get(CONF_PROTOCOL, DEFAULT_PROTOCOL)
         return await self._show_more_info_form("reconfigure", model, password, protocol)
+
+
+class PitBossOptionsFlow(OptionsFlow):
+    """Options for PitBoss.
+
+    The first options flow in this integration, added because remote start
+    needs somewhere to be turned on deliberately rather than being available
+    by default. Built as one field so anything else that wants an option --
+    #277's temperature unit, the polling intervals from #351 -- extends this
+    rather than introducing a second flow.
+    """
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Manage the options."""
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_ENABLE_REMOTE_START,
+                        default=self.config_entry.options.get(
+                            CONF_ENABLE_REMOTE_START, False
+                        ),
+                    ): bool,
+                }
+            ),
+        )

--- a/custom_components/pitboss/config_flow.py
+++ b/custom_components/pitboss/config_flow.py
@@ -17,7 +17,13 @@ from homeassistant.const import CONF_DEVICE_ID, CONF_MODEL, CONF_PASSWORD, CONF_
 from homeassistant.helpers.selector import SelectSelector, SelectSelectorConfig
 from pytboss import grills
 
-from .const import ALL_PROTOCOLS, DEFAULT_PROTOCOL, DOMAIN, LOGGER
+from .const import (
+    ALL_PROTOCOLS,
+    CONF_ENABLE_REMOTE_START,
+    DEFAULT_PROTOCOL,
+    DOMAIN,
+    LOGGER,
+)
 
 
 def _models_on_board(control_board: str) -> list[str]:

--- a/custom_components/pitboss/const.py
+++ b/custom_components/pitboss/const.py
@@ -59,3 +59,6 @@ MCU_SETTLE_SECONDS = 6
 The board wipes its cached status the moment it forwards a command to the
 MCU, so the next poll still carries the old value and an entity that read it
 straight back would appear to snap to the previous setting."""
+
+# Remote start is off unless the user turns it on in the integration options.
+CONF_ENABLE_REMOTE_START = "enable_remote_start"

--- a/custom_components/pitboss/services.py
+++ b/custom_components/pitboss/services.py
@@ -11,10 +11,24 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import device_registry as dr
 from pytboss.exceptions import Unauthorized
 
-from .const import DOMAIN, LOGGER
+from .const import CONF_ENABLE_REMOTE_START, DOMAIN, LOGGER
 from .coordinator import PitBossDataUpdateCoordinator
 
 SERVICE_SET_GRILL_PASSWORD = "set_grill_password"
+SERVICE_START_GRILL = "start_grill"
+
+# Conditions that make lighting the grill a bad idea. The board would likely
+# refuse or fail anyway, but failing here says why.
+BLOCKING_ERRORS = {
+    "noPellets": "the hopper reports no pellets",
+    "highTempErr": "the grill reports a high temperature error",
+    "erL": "the grill reports an ignition (ErL) error",
+    "fanErr": "the grill reports a fan error",
+    "motorErr": "the grill reports an auger error",
+    "hotErr": "the grill reports an igniter error",
+}
+
+START_GRILL_SCHEMA = vol.Schema({vol.Required(ATTR_DEVICE_ID): cv.string})
 
 SET_GRILL_PASSWORD_SCHEMA = vol.Schema(
     {
@@ -78,9 +92,45 @@ async def _async_set_grill_password(hass: HomeAssistant, call: ServiceCall) -> N
     LOGGER.info("Grill password %s", "removed" if not new_password else "updated")
 
 
+async def _async_start_grill(hass: HomeAssistant, call: ServiceCall) -> None:
+    """Light the grill, if the user has deliberately allowed it."""
+    coordinator, entry = _coordinator_for_device(hass, call.data[ATTR_DEVICE_ID])
+
+    if not entry.options.get(CONF_ENABLE_REMOTE_START, False):
+        raise ServiceValidationError(
+            "Remote start is disabled. Enable it in the integration options "
+            "first, and only if you accept lighting the grill without "
+            "standing next to it."
+        )
+
+    if not coordinator.api.is_connected():
+        raise HomeAssistantError("The grill is not connected.")
+
+    data = coordinator.data or {}
+    if data.get("moduleIsOn"):
+        raise HomeAssistantError("The grill is already on.")
+    for key, reason in BLOCKING_ERRORS.items():
+        if data.get(key):
+            raise HomeAssistantError(f"Refusing to start: {reason}.")
+
+    LOGGER.warning(
+        "Lighting the grill remotely. Make sure the lid is open and the burn "
+        "pot is clear of unburned pellets."
+    )
+    await coordinator.api.turn_grill_on()
+    await coordinator.async_request_refresh()
+
+
 @callback
 def async_register_services(hass: HomeAssistant) -> None:
     """Register PitBoss services."""
+
+    async def handle_start_grill(call: ServiceCall) -> None:
+        await _async_start_grill(hass, call)
+
+    hass.services.async_register(
+        DOMAIN, SERVICE_START_GRILL, handle_start_grill, schema=START_GRILL_SCHEMA
+    )
 
     async def handle_set_grill_password(call: ServiceCall) -> None:
         await _async_set_grill_password(hass, call)

--- a/custom_components/pitboss/services.yaml
+++ b/custom_components/pitboss/services.yaml
@@ -10,3 +10,10 @@ set_grill_password:
       selector:
         text:
           type: password
+start_grill:
+  fields:
+    device_id:
+      required: true
+      selector:
+        device:
+          integration: pitboss

--- a/custom_components/pitboss/switch.py
+++ b/custom_components/pitboss/switch.py
@@ -68,7 +68,10 @@ class PowerSwitch(BaseSwitchEntity):
 
     async def async_turn_on(self, **_: Any) -> None:
         """Turn on the switch."""
-        LOGGER.warning("For safety reasons, the grill cannot be turned on remotely.")
+        LOGGER.warning(
+            "Not lighting the grill from here. Use the pitboss.start_grill "
+            "action, which has to be enabled in the integration options first."
+        )
 
     async def async_turn_off(self, **_: Any) -> None:
         """Turn off the switch."""

--- a/custom_components/pitboss/translations/en.json
+++ b/custom_components/pitboss/translations/en.json
@@ -74,6 +74,28 @@
           "description": "The new password. Leave empty to remove it, which leaves the grill accepting commands from anyone who can reach it. Note the app has its own reset procedure for a forgotten password; removing it here works by setting an empty one, which the firmware treats as no password."
         }
       }
+    },
+    "start_grill": {
+      "name": "Start grill",
+      "description": "Lights the grill remotely. Disabled unless \"Allow starting the grill remotely\" is enabled in the integration options. Only start a pellet grill you have prepared: the lid open and the burn pot clear of unburned pellets.",
+      "fields": {
+        "device_id": {
+          "name": "Grill",
+          "description": "The grill to light."
+        }
+      }
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "enable_remote_start": "Allow starting the grill remotely"
+        },
+        "data_description": {
+          "enable_remote_start": "Lets the pitboss.start_grill action light the grill. Only turn this on if you accept starting a fire in an appliance nobody may be standing next to."
+        }
+      }
     }
   }
 }

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -9,7 +9,7 @@ from homeassistant.helpers import device_registry as dr
 from pytboss.exceptions import Unauthorized
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.pitboss.const import DOMAIN
+from custom_components.pitboss.const import CONF_ENABLE_REMOTE_START, DOMAIN
 
 pytestmark = pytest.mark.parametrize("model", ["PBV4PS2"])
 
@@ -136,3 +136,92 @@ async def test_a_rejected_password_offers_reauth(
     assert entry.data[CONF_PASSWORD] == "asdfasdf"
     flows = hass.config_entries.flow.async_progress_by_handler(DOMAIN)
     assert [f for f in flows if f["context"].get("source") == "reauth"]
+
+
+async def test_start_grill_refuses_unless_enabled(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+    mock_pitboss: Mock,
+) -> None:
+    """Off by default. Lighting a fire should be a deliberate choice."""
+    entry = await mock_add_config_entry()
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator.async_set_updated_data({"moduleIsOn": False})
+    await hass.async_block_till_done()
+
+    with pytest.raises(ServiceValidationError):
+        await hass.services.async_call(
+            DOMAIN, "start_grill", {"device_id": _device_id(hass)}, blocking=True
+        )
+
+    mock_pitboss.turn_grill_on.assert_not_awaited()
+
+
+async def test_start_grill_lights_the_grill(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+    mock_pitboss: Mock,
+) -> None:
+    entry = await mock_add_config_entry()
+    hass.config_entries.async_update_entry(
+        entry, options={CONF_ENABLE_REMOTE_START: True}
+    )
+    await hass.async_block_till_done()
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator.async_set_updated_data({"moduleIsOn": False})
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        DOMAIN, "start_grill", {"device_id": _device_id(hass)}, blocking=True
+    )
+
+    mock_pitboss.turn_grill_on.assert_awaited_once_with()
+
+
+@pytest.mark.parametrize(
+    "error", ["noPellets", "highTempErr", "erL", "fanErr", "motorErr", "hotErr"]
+)
+async def test_start_grill_refuses_on_an_error(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+    mock_pitboss: Mock,
+    error: str,
+) -> None:
+    """Every flag that means starting is a bad idea, not a sample of them."""
+    entry = await mock_add_config_entry()
+    hass.config_entries.async_update_entry(
+        entry, options={CONF_ENABLE_REMOTE_START: True}
+    )
+    await hass.async_block_till_done()
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator.async_set_updated_data({"moduleIsOn": False, error: True})
+    await hass.async_block_till_done()
+
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            DOMAIN, "start_grill", {"device_id": _device_id(hass)}, blocking=True
+        )
+
+    mock_pitboss.turn_grill_on.assert_not_awaited()
+
+
+async def test_start_grill_refuses_when_already_on(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+    mock_pitboss: Mock,
+) -> None:
+    entry = await mock_add_config_entry()
+    hass.config_entries.async_update_entry(
+        entry, options={CONF_ENABLE_REMOTE_START: True}
+    )
+    await hass.async_block_till_done()
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator.async_set_updated_data({"moduleIsOn": True})
+    await hass.async_block_till_done()
+
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            DOMAIN, "start_grill", {"device_id": _device_id(hass)}, blocking=True
+        )
+
+    mock_pitboss.turn_grill_on.assert_not_awaited()


### PR DESCRIPTION
Closes #322. Needs `pytboss 2026.8.4`, which `main` already pins.

Adds `pitboss.start_grill`, taking a device and nothing else. It calls `api.turn_grill_on()` — the method you asked for on #322 before anything downstream used it, added in [pytboss#550](https://github.com/dknowles2/pytboss/pull/550).

**Lighting a grill remotely is the most consequential thing this integration can do**, so the gating is the substance of the PR rather than a wrapper around it:

- **Off by default.** Refuses unless `enable_remote_start` is switched on in the integration options.
- Refuses if the grill is already on, or not connected.
- Refuses on `noPellets`, `highTempErr`, `erL`, `fanErr`, `motorErr`, `hotErr`. The board would likely fail anyway; failing here says which one.
- Logs a warning naming the lid and the burn pot before sending.
- Takes a **device**, so it does the right thing on a multi-grill setup rather than guessing at an entry.

There is a test per error flag rather than a sample of them, so removing one from the dict fails exactly its own test.

## It introduces the first options flow

The toggle has to live somewhere and this repo has none. So this adds one, with a single field, built so the next thing that wants an option extends it rather than bringing a second.

Two things about that:

**I recommended closing [#277](https://github.com/dknowles2/ha-pitboss/pull/277)** — its approach cannot work, because Home Assistant re-derives an entity's displayed unit from the unit system on every update, so an integration-level override never reaches the user. I demonstrated it and corrected my own earlier explanation of the mechanism there. If you would rather keep that PR and have it own the flow, say so and I will rebase onto it and drop the flow from here.

**It carries the update listener** whose absence I flagged on #277. Not needed for this toggle, which is read live — but an options flow without one is a trap for the next option added, and I would rather not build the trap.

## On testing

**Confirmed on hardware by both of us** — you on your PBV4PS2 as you said on the issue, me on a PB1600PS1 with the lid open and the burn pot clear.

**I have not re-run it since, deliberately.** There is no version of "just checking" this that is safe to do with nobody standing next to the grill, so everything here is verified against the released library and the test suite, and the live behaviour rests on those two runs.

142 tests, ruff, `ruff format --check` and mypy clean.
