### PR TITLE
Survive a null chamber reading instead of raising on it

### DIFF
--- a/custom_components/pitboss/climate.py
+++ b/custom_components/pitboss/climate.py
@@ -101,14 +101,22 @@ class GrillClimate(BaseEntity, ClimateEntity):
 
     @property
     def current_temperature(self) -> float | None:
-        if (data := self.coordinator.data) and "grillTemp" in data:
-            return float(data["grillTemp"])
+        # Checked for None, not just presence: the boards' own parsing
+        # routines put null on the wire for the no-reading sentinel (960),
+        # the same way an unplugged probe reads. `float(None)` would raise
+        # on every state write for as long as the chamber sensor is out.
+        if (data := self.coordinator.data) and (
+            temp := data.get("grillTemp")
+        ) is not None:
+            return float(temp)
         return None
 
     @property
     def target_temperature(self) -> float | None:
-        if (data := self.coordinator.data) and "grillSetTemp" in data:
-            return float(data["grillSetTemp"])
+        if (data := self.coordinator.data) and (
+            temp := data.get("grillSetTemp")
+        ) is not None:
+            return float(temp)
         return None
 
     async def async_set_temperature(self, **kwargs) -> None:

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -1,5 +1,6 @@
 from collections.abc import Awaitable, Callable
 from math import floor
+from typing import cast
 from unittest.mock import Mock
 
 import pytest
@@ -86,6 +87,31 @@ async def test_current_and_target_temperature(
     assert state is not None
     assert state.attributes["current_temperature"] == 225.0
     assert state.attributes["temperature"] == 250.0
+
+
+@pytest.mark.parametrize("model", ["PBV4PS2"])
+async def test_a_null_reading_is_unknown_not_a_crash(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+) -> None:
+    """The boards put null on the wire for the no-reading sentinel (960).
+
+    The same convertTemperature routine that gives an unplugged probe its
+    None gives the chamber sensor one too. Coercing that with float() raised
+    on every state write for as long as the sensor was out.
+    """
+    entry = await mock_add_config_entry()
+    coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+
+    coordinator.async_set_updated_data(
+        cast(StateDict, {"grillTemp": None, "grillSetTemp": None, "isFahrenheit": True})
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.attributes.get("current_temperature") is None
+    assert state.attributes.get("temperature") is None
 
 
 @pytest.mark.parametrize("model", ["PBV4PS2"])


### PR DESCRIPTION
Found in a review pass over `main`; no issue filed, the defect and fix fit in one description.

The boards' own parsing routines put null on the wire for the no-reading sentinel (960) — `grillTemp` and `grillSetTemp` go through the same `convertTemperature` helper that gives an unplugged probe its `None`. The climate entity checked for the *key's presence* but coerced the value with `float()` unconditionally, so a chamber sensor that drops out (RTD fault, disconnect) made `current_temperature` raise `TypeError` on every state write until it came back. The probe sensors already pass the same value through as unknown; climate was alone in coercing.

Fix is the guard the probes effectively have: `None` reads as unknown, everything else as before. One new test drives both fields with null and asserts the attributes are simply absent — no test covered the sentinel value on the chamber fields before.

Verification: full suite green on Linux (134 passed, `python:3.14` container — macOS cannot run the suite natively per AGENTS.md); `ruff check`, `ruff format --check`, `mypy .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)