### PR TITLE
Back off on a pattern of failures, not a single miss

### DIFF
--- a/custom_components/pitboss/const.py
+++ b/custom_components/pitboss/const.py
@@ -20,6 +20,11 @@ MANUFACTURER = NAME
 # yet. They are the two values that would become fields when it grows one.
 ACTIVE_SCAN_INTERVAL = timedelta(seconds=10)
 STANDBY_SCAN_INTERVAL = timedelta(seconds=60)
+# Consecutive failed cycles before the poll interval backs off. One failure
+# is as likely a mid-cook hiccup as a grill gone away, and backing off on it
+# turns a lost ten-second poll into a sixty-second gap in the one situation
+# where freshness matters most. Two in a row is a pattern.
+FAILURES_BEFORE_BACKOFF = 2
 # Diagnostics change slowly; no need to read them at the poll rate.
 SYS_INFO_INTERVAL = 60.0
 PROTOCOL_WSS = "wss"

--- a/custom_components/pitboss/coordinator.py
+++ b/custom_components/pitboss/coordinator.py
@@ -23,6 +23,7 @@ from pytboss.grills import StateDict
 from .const import (
     ACTIVE_SCAN_INTERVAL,
     DOMAIN,
+    FAILURES_BEFORE_BACKOFF,
     LOGGER,
     STANDBY_SCAN_INTERVAL,
     SYS_INFO_INTERVAL,
@@ -66,6 +67,8 @@ class PitBossDataUpdateCoordinator(DataUpdateCoordinator[StateDict]):
         self.probe_targets: dict[int, int] = {}
         self.restored_targets: dict[int, int] = {}
         self._targets_seeded = False
+        # Consecutive failed cycles, for the backoff decision below.
+        self._failed_polls = 0
 
     def accepted_setpoints(self, unit: str) -> list[float]:
         """Grill setpoints the control board honours, expressed in `unit`.
@@ -287,17 +290,24 @@ class PitBossDataUpdateCoordinator(DataUpdateCoordinator[StateDict]):
 
     async def _async_update_data(self) -> StateDict:
         try:
-            return await self._async_poll()
+            state = await self._async_poll()
         except UpdateFailed:
-            # Back off before giving up on this cycle. The interval is
-            # otherwise whatever the last *successful* read set, so a grill
-            # that goes off while the connection stays up -- which is the
+            # Back off, but on a pattern rather than a single miss. The
+            # interval is otherwise whatever the last *successful* read set,
+            # so a grill that goes off while the connection stays up -- the
             # normal case on the cloud relay, where the socket outlives the
-            # grill -- keeps a ten-second ping in flight for as long as it
-            # is off, which is the opposite of what the two intervals exist
-            # for.
-            self._apply_poll_interval(StateDict())
+            # grill -- kept a ten-second ping in flight for as long as it
+            # was off. But one failure is as likely a mid-cook hiccup as a
+            # grill gone away, and backing off on it turned a lost ten-second
+            # poll into a sixty-second gap exactly when freshness matters
+            # most. A grill that is genuinely off fails every cycle, so it
+            # still reaches the slow interval, one failed poll later.
+            self._failed_polls += 1
+            if self._failed_polls >= FAILURES_BEFORE_BACKOFF:
+                self._apply_poll_interval(StateDict())
             raise
+        self._failed_polls = 0
+        return state
 
     async def _async_poll(self) -> StateDict:
         if not self._api_started:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -173,14 +173,17 @@ async def test_a_ping_timeout_is_reported_as_a_failed_update(
         await coordinator._async_update_data()
 
 
-async def test_a_failed_cycle_backs_the_poll_interval_off(
+async def test_repeated_failures_back_the_poll_interval_off(
     coordinator: PitBossDataUpdateCoordinator, mock_pitboss: Mock
 ) -> None:
     """The interval was otherwise whatever the last success set.
 
     On the cloud relay the socket outlives the grill, so a grill switched
     off keeps failing at the active cadence -- a ten-second ping in flight
-    for as long as it is off.
+    for as long as it is off. One failure keeps the interval: it is as
+    likely a mid-cook hiccup as a grill gone away, and backing off on it
+    turned a lost ten-second poll into a sixty-second gap exactly when
+    freshness matters most. A pattern of them backs off.
     """
     coordinator._api_started = True
     mock_pitboss.is_connected.return_value = True
@@ -190,5 +193,35 @@ async def test_a_failed_cycle_backs_the_poll_interval_off(
     mock_pitboss.ping.side_effect = TimeoutError()
     with pytest.raises(UpdateFailed):
         await coordinator._async_update_data()
+    assert coordinator.update_interval == ACTIVE_SCAN_INTERVAL
 
+    with pytest.raises(UpdateFailed):
+        await coordinator._async_update_data()
     assert coordinator.update_interval == STANDBY_SCAN_INTERVAL
+
+
+async def test_a_success_resets_the_failure_pattern(
+    coordinator: PitBossDataUpdateCoordinator, mock_pitboss: Mock
+) -> None:
+    """Isolated failures never accumulate into a backoff.
+
+    Only consecutive ones make the pattern; a success in between means the
+    grill is there and the cadence should stay whatever its state asks for.
+    """
+    coordinator._api_started = True
+    mock_pitboss.is_connected.return_value = True
+    coordinator._apply_poll_interval(StateDict(moduleIsOn=True))
+
+    mock_pitboss.ping.side_effect = TimeoutError()
+    with pytest.raises(UpdateFailed):
+        await coordinator._async_update_data()
+    assert coordinator.update_interval == ACTIVE_SCAN_INTERVAL
+
+    mock_pitboss.ping.side_effect = None
+    mock_pitboss.get_state.return_value = StateDict(moduleIsOn=True)
+    await coordinator._async_update_data()
+
+    mock_pitboss.ping.side_effect = TimeoutError()
+    with pytest.raises(UpdateFailed):
+        await coordinator._async_update_data()
+    assert coordinator.update_interval == ACTIVE_SCAN_INTERVAL


### PR DESCRIPTION
A refinement of my own #366, offered as a decision rather than left as an oversight — the same courtesy #356 got.

#366 backs the poll interval off when a cycle fails, so a grill switched off behind the relay's ever-open socket stops eating a ten-second ping forever. Correct — but it triggers on the *first* failure, and one failure is as likely a mid-cook Bluetooth hiccup as a grill gone away. The cost lands exactly where freshness matters most: one lost ten-second poll during a cook became a sixty-second gap in temperatures.

This makes the trigger a pattern: two consecutive failures. The trade in numbers:

- **Mid-cook hiccup** (the common transient): before, a 60s data gap; now, the next poll comes 10s later as if nothing happened.
- **Grill actually off** (what #366 exists for): reaches the slow interval one failed poll later than before — 10 extra seconds of fast polling against a dead grill, once.

A success resets the count, so isolated failures never accumulate. `FAILURES_BEFORE_BACKOFF = 2` sits next to the two intervals in `const.py` with the reasoning; the existing backoff test now walks both cycles, and a new one pins that an isolated failure between successes never backs off.

Verification: full suite green on Linux (134 passed, `python:3.14` container — macOS cannot run the suite natively per AGENTS.md); `ruff check`, `ruff format --check`, `mypy .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)