### PR TITLE
Hold the asked-for setpoint until the grill confirms it

### DIFF
--- a/custom_components/pitboss/climate.py
+++ b/custom_components/pitboss/climate.py
@@ -101,14 +101,22 @@ class GrillClimate(BaseEntity, ClimateEntity):
 
     @property
     def current_temperature(self) -> float | None:
-        if (data := self.coordinator.data) and "grillTemp" in data:
-            return float(data["grillTemp"])
+        # Checked for None, not just presence: the boards' own parsing
+        # routines put null on the wire for the no-reading sentinel (960),
+        # the same way an unplugged probe reads. `float(None)` would raise
+        # on every state write for as long as the chamber sensor is out.
+        if (data := self.coordinator.data) and (
+            temp := data.get("grillTemp")
+        ) is not None:
+            return float(temp)
         return None
 
     @property
     def target_temperature(self) -> float | None:
-        if (data := self.coordinator.data) and "grillSetTemp" in data:
-            return float(data["grillSetTemp"])
+        if (data := self.coordinator.data) and (
+            temp := data.get("grillSetTemp")
+        ) is not None:
+            return float(temp)
         return None
 
     async def async_set_temperature(self, **kwargs) -> None:

--- a/custom_components/pitboss/climate.py
+++ b/custom_components/pitboss/climate.py
@@ -13,11 +13,18 @@ from homeassistant.components.climate.const import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
-from homeassistant.core import HomeAssistant
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.event import async_call_later
 from homeassistant.util.unit_conversion import TemperatureConverter
 
-from .const import DEFAULT_MAX_TEMP, DEFAULT_MIN_TEMP, DOMAIN, LOGGER
+from .const import (
+    DEFAULT_MAX_TEMP,
+    DEFAULT_MIN_TEMP,
+    DOMAIN,
+    LOGGER,
+    MCU_SETTLE_SECONDS,
+)
 from .coordinator import PitBossDataUpdateCoordinator
 from .entity import BaseEntity
 
@@ -50,6 +57,22 @@ class GrillClimate(BaseEntity, ClimateEntity):
             name="Grill temperature",
         )
         self._attr_unique_id = f"{self.entity_description.key}_{entry_unique_id}"
+        self._pending_target: float | None = None
+        self._cancel_settle: CALLBACK_TYPE | None = None
+
+    async def async_added_to_hass(self) -> None:
+        """Register the one removal callback this entity needs."""
+        await super().async_added_to_hass()
+        # Registered once rather than per set: `async_on_remove` only
+        # appends, so re-registering would grow the list for the life of
+        # the entity.
+        self.async_on_remove(self._cancel_pending_settle)
+
+    @callback
+    def _cancel_pending_settle(self) -> None:
+        if self._cancel_settle is not None:
+            self._cancel_settle()
+            self._cancel_settle = None
 
     @property
     def _accepted_setpoints(self) -> list[float]:
@@ -113,16 +136,61 @@ class GrillClimate(BaseEntity, ClimateEntity):
 
     @property
     def target_temperature(self) -> float | None:
+        """The grill's setpoint, or the one just asked for.
+
+        Shows what was asked until the grill confirms it: the board wipes
+        its cached status the moment it forwards a command to the MCU, so
+        the next poll still carries the old setpoint and the slider would
+        appear to snap back. The select and the probe targets already work
+        this way; the climate card was the one control that did not.
+        """
+        if self._pending_target is not None:
+            return self._pending_target
         if (data := self.coordinator.data) and (
             temp := data.get("grillSetTemp")
         ) is not None:
             return float(temp)
         return None
 
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        if self._pending_target is not None:
+            reported = (self.coordinator.data or {}).get("grillSetTemp")
+            if reported is not None and float(reported) == self._pending_target:
+                self._pending_target = None
+        super()._handle_coordinator_update()
+
     async def async_set_temperature(self, **kwargs) -> None:
         if (temp := kwargs.get(ATTR_TEMPERATURE)) is None:
             return
-        await self.coordinator.api.set_grill_temperature(temp)
+        # Snapped here as well as in pytboss -- deliberately the same
+        # arithmetic -- so what is held and shown is the value the board
+        # will actually report, not the one it will silently correct.
+        wanted = float(temp)
+        if accepted := self._accepted_setpoints:
+            asked = wanted
+            wanted = min(accepted, key=lambda value: abs(value - asked))
+        await self.coordinator.api.set_grill_temperature(int(wanted))
+        self._pending_target = wanted
+        self.async_write_ha_state()
+        # The MCU reports back within a couple of seconds; an immediate
+        # refresh would only read the cleared status. A second set inside
+        # the window replaces the timer rather than queueing another.
+        self._cancel_pending_settle()
+        self._cancel_settle = async_call_later(
+            self.hass, MCU_SETTLE_SECONDS, self._async_confirm
+        )
+
+    async def _async_confirm(self, _now) -> None:
+        self._cancel_settle = None
+        await self.coordinator.async_request_refresh()
+        # One settle window is all the pending value is for. If the refresh
+        # confirmed it, `_handle_coordinator_update` has already cleared it;
+        # if the grill did not take it, follow the grill rather than assert
+        # a value it will never report.
+        if self._pending_target is not None:
+            self._pending_target = None
+            self.async_write_ha_state()
 
     async def async_turn_off(self) -> None:
         """Turn off the grill."""

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -1,5 +1,6 @@
 from collections.abc import Awaitable, Callable
 from math import floor
+from typing import cast
 from unittest.mock import Mock
 
 import pytest
@@ -86,6 +87,31 @@ async def test_current_and_target_temperature(
     assert state is not None
     assert state.attributes["current_temperature"] == 225.0
     assert state.attributes["temperature"] == 250.0
+
+
+@pytest.mark.parametrize("model", ["PBV4PS2"])
+async def test_a_null_reading_is_unknown_not_a_crash(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+) -> None:
+    """The boards put null on the wire for the no-reading sentinel (960).
+
+    The same convertTemperature routine that gives an unplugged probe its
+    None gives the chamber sensor one too. Coercing that with float() raised
+    on every state write for as long as the sensor was out.
+    """
+    entry = await mock_add_config_entry()
+    coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+
+    coordinator.async_set_updated_data(
+        cast(StateDict, {"grillTemp": None, "grillSetTemp": None, "isFahrenheit": True})
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.attributes.get("current_temperature") is None
+    assert state.attributes.get("temperature") is None
 
 
 @pytest.mark.parametrize("model", ["PBV4PS2"])

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -1,4 +1,5 @@
 from collections.abc import Awaitable, Callable
+from datetime import timedelta
 from math import floor
 from typing import cast
 from unittest.mock import Mock
@@ -7,11 +8,15 @@ import pytest
 from conftest import get_entity
 from homeassistant.components.climate.const import HVACAction, HVACMode
 from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
 from pytboss.grills import StateDict
-from pytest_homeassistant_custom_component.common import MockConfigEntry
+from pytest_homeassistant_custom_component.common import (
+    MockConfigEntry,
+    async_fire_time_changed,
+)
 
 from custom_components.pitboss.climate import GrillClimate
-from custom_components.pitboss.const import DOMAIN
+from custom_components.pitboss.const import DOMAIN, MCU_SETTLE_SECONDS
 from custom_components.pitboss.coordinator import PitBossDataUpdateCoordinator
 
 ENTITY_ID = "climate.mygrill_grill_temperature"
@@ -163,7 +168,105 @@ async def test_set_temperature(
         {"entity_id": ENTITY_ID, "temperature": 275},
         blocking=True,
     )
-    mock_pitboss.set_grill_temperature.assert_awaited_once_with(275)
+    # PBV4PS2's board takes setpoints in tens; 275 is not on its list. The
+    # entity snaps with the same arithmetic pytboss does, so what is sent --
+    # and shown -- is the value the board will actually report.
+    mock_pitboss.set_grill_temperature.assert_awaited_once_with(270)
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.attributes["temperature"] == 270.0
+
+
+@pytest.mark.parametrize("model", ["PBV4PS2"])
+async def test_the_setpoint_holds_until_the_grill_confirms_it(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+    mock_pitboss: Mock,
+) -> None:
+    """The board wipes its status when it forwards a command to the MCU.
+
+    So the poll right after a set still carries the old setpoint, and the
+    slider snapped back to it. The asked-for value holds until the grill
+    reports it -- or until the settle window ends, after which the grill's
+    own answer wins, whatever it is.
+    """
+    entry = await mock_add_config_entry()
+    coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator.async_set_updated_data(
+        {"moduleIsOn": True, "isFahrenheit": True, "grillSetTemp": 250}
+    )
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        "climate",
+        "set_temperature",
+        {"entity_id": ENTITY_ID, "temperature": 300},
+        blocking=True,
+    )
+
+    # A poll lands still carrying the old setpoint; the asked-for one holds.
+    coordinator.async_set_updated_data(
+        {"moduleIsOn": True, "isFahrenheit": True, "grillSetTemp": 250}
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.attributes["temperature"] == 300.0
+
+    # The grill reports the new setpoint; from here it is the source again.
+    coordinator.async_set_updated_data(
+        {"moduleIsOn": True, "isFahrenheit": True, "grillSetTemp": 300}
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.attributes["temperature"] == 300.0
+
+    coordinator.async_set_updated_data(
+        {"moduleIsOn": True, "isFahrenheit": True, "grillSetTemp": 250}
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.attributes["temperature"] == 250.0
+
+
+@pytest.mark.parametrize("model", ["PBV4PS2"])
+async def test_an_unconfirmed_setpoint_expires_with_the_settle_window(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+    mock_pitboss: Mock,
+) -> None:
+    """If the grill never takes the value, the entity stops asserting it."""
+    entry = await mock_add_config_entry()
+    coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator.async_set_updated_data(
+        {"moduleIsOn": True, "isFahrenheit": True, "grillSetTemp": 250}
+    )
+    await hass.async_block_till_done()
+    mock_pitboss.get_state.reset_mock()
+
+    await hass.services.async_call(
+        "climate",
+        "set_temperature",
+        {"entity_id": ENTITY_ID, "temperature": 300},
+        blocking=True,
+    )
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.attributes["temperature"] == 300.0
+
+    async_fire_time_changed(
+        hass, dt_util.utcnow() + timedelta(seconds=MCU_SETTLE_SECONDS + 1)
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.attributes["temperature"] == 250.0
+    # The window also asks the grill again rather than waiting out the poll.
+    assert mock_pitboss.get_state.await_count >= 1
 
 
 @pytest.mark.parametrize("model", ["PBV4PS2"])


### PR DESCRIPTION
The climate card was the one control left out of the settle pattern. The board wipes its cached status the moment it forwards a command to the MCU, so the poll right after a set still carries the *old* setpoint — the unit select (#347) and the probe targets (#341) hold what was asked for `MCU_SETTLE_SECONDS` and then believe the grill again, but the climate slider snapped back to the stale value for up to a full poll cycle.

Same mechanism as its siblings, deliberately: a pending value shown until the grill reports it, one settle timer that a second set replaces rather than queues, a refresh when the window closes, and the grill's own answer winning after that — if the board never took the value, the entity stops asserting it.

One visible improvement beyond the hold: **the setpoint is snapped locally with the same arithmetic pytboss applies** (`min(accepted, key=...)` over the same list), so what is held and shown is the value the board will actually report rather than the one it silently corrects. The existing `test_set_temperature` now documents that — asking 275 of a board with a tens list sends and shows 270. Two new tests walk the hold: a stale poll inside the window does not snap the slider back, a confirming report hands control back to the grill, and an unconfirmed value expires with the window.

Stacked on #372 (`climate-survives-a-null-reading`) — both touch `climate.py`, and this builds on its guarded `target_temperature`. The diff includes that commit until it lands; I will rebase the moment it does, same as #356.

Verification: full suite green on Linux (136 passed, `python:3.14` container — macOS cannot run the suite natively per AGENTS.md); `ruff check`, `ruff format --check`, `mypy .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)