### PR TITLE
Declare the floor and the flame the code actually has

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ dependency is updated.
 - **Reconfigurable, and it asks rather than gives up.** Change the model, password, or protocol without deleting the integration. If the grill starts rejecting the password, the integration asks you to re-enter it instead of retrying forever.
 - **Adapts to your grill.** The light, primer motor, recipe sensors, probe count, probe naming, and per-probe targets are all created from what your model and control board declare — not assumed.
 - **Polls faster when it matters.** Updates arrive quickly while the grill is running and back off in standby.
-- **Safety first.** The integration cannot turn the grill on remotely. You can monitor it and turn it off.
+- **Safety first, remote start off by default.** Out of the box the integration cannot light the grill: the power switch and climate card only ever turn it off. A deliberate opt-in in the integration options enables the `pitboss.start_grill` action -- and only that action; the switch and climate card refuse either way.
 
 ### Connection protocols
 
@@ -72,6 +72,7 @@ A genuinely local option exists in the grill's firmware and is being added to [p
 ### Actions
 
 - **`pitboss.set_grill_password`:** Sets the grill's connection password and stores it in the config entry, so the two cannot drift apart.
+- **`pitboss.start_grill`:** Lights the grill remotely. Refused unless "Allow starting the grill remotely" is enabled in the integration options, and refused while the grill is on, disconnected, or reporting an error such as an empty hopper. Only light a grill you have prepared: lid open, burn pot clear of unburned pellets.
 
 ## Installation
 

--- a/hacs.json
+++ b/hacs.json
@@ -1,7 +1,7 @@
 {
     "name": "PitBoss",
     "render_readme": true,
-    "homeassistant": "2024.1.0",
+    "homeassistant": "2025.1.0",
     "hacs": "1.34.0",
     "zip_release": true,
     "filename": "pitboss.zip"


### PR DESCRIPTION
Two findings from a full three-pass audit of `main`, grouped because both are the same defect: what the repo *declares* diverged from what it *does*. No code changes.

**`hacs.json` admitted installs a year older than the code supports.** The floor said 2024.1.0, but the code needs `ConfigFlowResult` (2024.2), the coordinator `_async_setup` hook (2024.8 — on older HA it is silently never called, so `subscribe_state` never registers and push updates are dropped with no error), `_get_reauth_entry`/`_get_reconfigure_entry` and the implicit `OptionsFlow.config_entry` (2024.11), and `_abort_if_unique_id_mismatch` (~2024.12). A user on HA 2024.10 passes the HACS gate and then gets "Config flow could not be loaded" with nothing saying why. 2025.1.0 is the first round floor above all of them.

**The README's headline safety claim stopped being true when #370 merged.** "The integration cannot turn the grill on remotely" — it can, behind the opt-in, and the Actions section did not mention `pitboss.start_grill` at all. Anyone granting automations or a voice assistant access to the service surface on the strength of that sentence was working from a false premise. The bullet now states the real invariant — off by default, one deliberately-enabled action, the switch and climate card refuse either way — and the action is documented next to its sibling with the same preparation warning the service description carries.

Verification: full suite green on Linux (146 passed, `python:3.14` container — macOS cannot run the suite natively per AGENTS.md); ruff, `ruff format --check`, mypy clean. Note #371 also edits the README; different sections, and whichever lands second reconciles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)