### PR TITLE
Let reconfigure keep the entries setup promises to keep

### DIFF
--- a/custom_components/pitboss/config_flow.py
+++ b/custom_components/pitboss/config_flow.py
@@ -117,6 +117,17 @@ class PitBossFlowHandler(ConfigFlow, domain=DOMAIN):
         # since there is no entry yet whose setup could have warmed the
         # cache.
         models = await self.hass.async_add_executor_job(_models_on_board, control_board)
+        # Reconfigure mirrors the tolerance setup already has: an entry from
+        # the board-remap era can hold a model that was never sold under the
+        # advertised prefix, and `async_setup_entry` deliberately keeps those
+        # working by falling back to by-name resolution. Without this, that
+        # same entry hits a hard `unknown_grill` abort here (unknown prefix),
+        # or a model list its own stored model is not in -- so its owner
+        # could not re-save a working configuration, and the only
+        # submittable choices switched the entry onto a different board's
+        # parsing routines.
+        if isinstance(model, str) and model not in models:
+            models = [model, *models]
         if not models:
             return self.async_abort(
                 reason="unknown_grill",

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -229,6 +229,93 @@ async def test_reconfigure_flow_updates_entry(
 
 
 @pytest.mark.parametrize("model", ["PBV4PS2"])
+async def test_reconfigure_keeps_a_remap_era_entry_editable(
+    hass: HomeAssistant,
+    mock_wss_conn: Mock,
+    mock_pitboss: Mock,
+) -> None:
+    """An entry whose prefix matches no board can still be re-saved.
+
+    Setup deliberately keeps such entries working by falling back to
+    by-name resolution; reconfigure used to hard-abort with unknown_grill,
+    so their owners could not change a password or protocol at all.
+    """
+    mock_pitboss.get_state.return_value = {}
+    entry = MockConfigEntry(
+        title="title",
+        domain=DOMAIN,
+        data={
+            CONF_DEVICE_ID: "mygrill",
+            CONF_MODEL: "PBV4PS2",
+            CONF_PASSWORD: "oldpw",
+            CONF_PROTOCOL: PROTOCOL_WSS,
+        },
+        unique_id="mygrill",
+    )
+    entry.add_to_hass(hass)
+
+    result = await entry.start_reconfigure_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_MODEL: "PBV4PS2",
+            CONF_PASSWORD: "newpw",
+            CONF_PROTOCOL: PROTOCOL_WSS,
+        },
+    )
+    await hass.async_block_till_done()
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert entry.data[CONF_PASSWORD] == "newpw"
+
+
+@pytest.mark.parametrize("model", ["PBV4PS2"])
+async def test_reconfigure_offers_the_stored_model_off_its_board(
+    hass: HomeAssistant,
+    mock_wss_conn: Mock,
+    mock_pitboss: Mock,
+) -> None:
+    """A stored model missing from the advertised board stays selectable.
+
+    Without it, the form's model list did not contain the entry's own
+    model, and the only submittable choices moved the entry onto a
+    different board's parsing routines.
+    """
+    mock_pitboss.get_state.return_value = {}
+    entry = MockConfigEntry(
+        title="title",
+        domain=DOMAIN,
+        data={
+            # PBL2 is a real board, but PBV4PS2 is not sold on it.
+            CONF_DEVICE_ID: "PBL2-ABC123",
+            CONF_MODEL: "PBV4PS2",
+            CONF_PASSWORD: "oldpw",
+            CONF_PROTOCOL: PROTOCOL_WSS,
+        },
+        unique_id="pbl2-abc123",
+    )
+    entry.add_to_hass(hass)
+
+    result = await entry.start_reconfigure_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_MODEL: "PBV4PS2",
+            CONF_PASSWORD: "oldpw",
+            CONF_PROTOCOL: PROTOCOL_WSS,
+        },
+    )
+    await hass.async_block_till_done()
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert entry.data[CONF_MODEL] == "PBV4PS2"
+
+
+@pytest.mark.parametrize("model", ["PBV4PS2"])
 async def test_reauth_updates_the_password_and_reloads(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,


### PR DESCRIPTION
From the same audit. Setup deliberately tolerates an entry from the board-remap era (#119/#315) whose stored model was never sold under its advertised prefix — `async_setup_entry` falls back to by-name resolution with a warning, "those keep working unchanged." Reconfigure did not mirror that tolerance, so exactly those entries hit a dead end in a first-class flow:

- **Unknown prefix** (`mygrill`-style IDs from the era): `_show_more_info_form` finds no models and hard-aborts the whole flow with `unknown_grill` — the owner cannot change a password or protocol at all.
- **Known board, stored model not on it**: the form's `vol.In` does not contain the entry's own model, so a working configuration cannot be re-saved, and every submittable choice moves the entry onto a different board's parsing routines.

The fix is one conditional: when a stored model exists and is not among the board's models, it is prepended to the choices. First-time setup is untouched — with no stored model the fallback cannot engage, and a genuinely unknown grill still aborts (the existing `test_user_flow_unknown_grill_aborts` pins that).

Two new tests, one per dead end: an unknown-prefix entry can re-save with a new password, and a stored model off its advertised board stays selectable and survives a round-trip.

Verification: full suite green on Linux (148 passed, `python:3.14` container); ruff, `ruff format --check`, mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)