### PR TITLE
Reload on options changes only when an option asks for it

### DIFF
--- a/custom_components/pitboss/__init__.py
+++ b/custom_components/pitboss/__init__.py
@@ -172,15 +172,27 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
-async def _async_options_updated(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    """Reload when the options change.
+RELOAD_OPTIONS: frozenset[str] = frozenset()
+"""Options whose change requires reloading the entry.
 
-    The remote-start toggle is read live, so this is not strictly needed for
-    it -- but an options flow without a listener is a trap for the next
-    option added, and Home Assistant fixes some entity properties (a display
-    unit, for one) when the entity is registered.
-    """
-    await hass.config_entries.async_reload(entry.entry_id)
+Empty because every option that exists today -- the remote-start toggle --
+is read live where it is used. An option that fixes something at entity
+registration (a display unit, a polling interval baked into the
+coordinator) belongs in this set when it is added.
+
+The set exists because reloading unconditionally has a real cost: on
+Bluetooth a reload waits for the grill to advertise again, so flipping a
+toggle while the grill was asleep took the whole integration down --
+entities and all -- until the grill next woke up. The listener stays
+registered so a future option cannot forget to think about this; it just
+reloads only when the option asks for it.
+"""
+
+
+async def _async_options_updated(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Reload when an option that needs a reload changes."""
+    if RELOAD_OPTIONS:
+        await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -11,6 +11,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.pitboss.const import (
     ACTIVE_SCAN_INTERVAL,
+    CONF_ENABLE_REMOTE_START,
     DOMAIN,
     PROTOCOL_BLE,
     PROTOCOL_WSS,
@@ -169,6 +170,28 @@ async def test_connect_ble_timeout_raises_not_ready(
         await hass.async_block_till_done()
 
     assert entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_changing_a_live_option_does_not_reload_the_entry(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+) -> None:
+    """Every current option is read live, so saving one must not reload.
+
+    A reload is not free: on Bluetooth it waits for the grill to advertise
+    again, so flipping a toggle while the grill was asleep took the whole
+    integration down until the grill next woke up.
+    """
+    entry = await mock_add_config_entry()
+    coordinator_before = hass.data[DOMAIN][entry.entry_id]
+
+    hass.config_entries.async_update_entry(
+        entry, options={CONF_ENABLE_REMOTE_START: True}
+    )
+    await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.LOADED
+    assert hass.data[DOMAIN][entry.entry_id] is coordinator_before
 
 
 async def test_unload_entry_stops_api(


### PR DESCRIPTION
From the same audit — a refinement of my own listener from #370, offered as a decision the way #373 refined #366.

The options listener reloaded the entry on every save. A reload is not free: **on Bluetooth it waits for the grill to advertise again**, up to the 30s `_connect_ble` window and then `ConfigEntryNotReady` retries — so flipping the remote-start toggle while the grill was asleep, which is exactly the prepare-for-later case that toggle exists for, took the whole integration down, entities and all, until the grill next woke up. And the one option that exists is read live at its point of use, so the reload bought nothing.

The listener stays registered, and the trap it guarded against stays guarded — just declaratively: `RELOAD_OPTIONS` names the options that fix something at entity registration, the listener reloads when the set is non-empty, and its docstring says both why it is empty today and what belongs in it tomorrow. A future option has one obvious place to declare itself, next to the reasoning about what an unconditional reload costs.

New test pins the behaviour: saving a live-read option on a loaded entry leaves the entry loaded and the coordinator object identity unchanged. The service-gating tests already prove the flag is honoured without a reload.

Verification: full suite green on Linux (147 passed, `python:3.14` container); ruff, `ruff format --check`, mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)