### PR TITLE
Agree with the command path on what an absent unit flag means

### DIFF
--- a/custom_components/pitboss/climate.py
+++ b/custom_components/pitboss/climate.py
@@ -118,7 +118,10 @@ class GrillClimate(BaseEntity, ClimateEntity):
 
     @property
     def temperature_unit(self) -> str:
-        if (data := self.coordinator.data) and not data.get("isFahrenheit", False):
+        # Absent defaults to Fahrenheit -- the same default pytboss snaps
+        # setpoints with, so the unit shown and the unit commanded agree
+        # even on a state built from a status frame alone.
+        if (data := self.coordinator.data) and not data.get("isFahrenheit", True):
             return UnitOfTemperature.CELSIUS
         return UnitOfTemperature.FAHRENHEIT
 

--- a/custom_components/pitboss/coordinator.py
+++ b/custom_components/pitboss/coordinator.py
@@ -94,8 +94,17 @@ class PitBossDataUpdateCoordinator(DataUpdateCoordinator[StateDict]):
 
     @property
     def grill_unit(self) -> str:
-        """The unit the grill is currently working in."""
-        if (data := self.data) and not data.get("isFahrenheit"):
+        """The unit the grill is currently working in.
+
+        Absent defaults to Fahrenheit, matching pytboss's `_is_fahrenheit` --
+        the default the command path snaps setpoints with. The key is only
+        emitted by the temperatures frame on most boards, so a state built
+        from a status frame alone (a poll landing right after the firmware
+        wipes the other half) is non-empty without it; reading that as
+        Celsius meant presenting one unit while commands were snapped in the
+        other.
+        """
+        if (data := self.data) and not data.get("isFahrenheit", True):
             return UnitOfTemperature.CELSIUS
         return UnitOfTemperature.FAHRENHEIT
 

--- a/custom_components/pitboss/select.py
+++ b/custom_components/pitboss/select.py
@@ -77,7 +77,7 @@ class GrillTemperatureUnitSelect(BaseEntity, SelectEntity):
     @property
     def _reported_option(self) -> str | None:
         if data := self.coordinator.data:
-            return UNIT_FAHRENHEIT if data.get("isFahrenheit") else UNIT_CELSIUS
+            return UNIT_FAHRENHEIT if data.get("isFahrenheit", True) else UNIT_CELSIUS
         return None
 
     @property

--- a/custom_components/pitboss/sensor.py
+++ b/custom_components/pitboss/sensor.py
@@ -156,7 +156,7 @@ class ProbeSensor(BaseSensorEntity):
 
     @property
     def native_unit_of_measurement(self) -> str | None:
-        if (data := self.coordinator.data) and not data.get("isFahrenheit"):
+        if (data := self.coordinator.data) and not data.get("isFahrenheit", True):
             return UnitOfTemperature.CELSIUS
         return UnitOfTemperature.FAHRENHEIT
 

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -120,6 +120,28 @@ async def test_a_null_reading_is_unknown_not_a_crash(
 
 
 @pytest.mark.parametrize("model", ["PBV4PS2"])
+async def test_absent_unit_flag_reads_as_fahrenheit(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+) -> None:
+    """A state built from a status frame alone carries no isFahrenheit.
+
+    Most boards emit the flag only in the temperatures frame. The entity
+    must default to the unit pytboss snaps commands with -- Fahrenheit --
+    or the unit shown and the unit commanded disagree for the window.
+    """
+    entry = await mock_add_config_entry()
+    coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator.async_set_updated_data({"moduleIsOn": True, "grillSetTemp": 250})
+    await hass.async_block_till_done()
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    # The Fahrenheit step; the Celsius default read this as 1.0.
+    assert state.attributes["target_temp_step"] == 5.0
+
+
+@pytest.mark.parametrize("model", ["PBV4PS2"])
 async def test_set_temperature_noop_without_temperature_kwarg(
     hass: HomeAssistant,
     mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -39,6 +39,14 @@ async def test_reports_the_unit_the_grill_is_in(
     assert state is not None
     assert state.state == "°C"
 
+    # A state without the flag -- a status frame alone -- reads as the
+    # default the command path uses, Fahrenheit, not Celsius.
+    coordinator.async_set_updated_data({"moduleIsOn": True})
+    await hass.async_block_till_done()
+    state = hass.states.get("select.mygrill_grill_temperature_unit")
+    assert state is not None
+    assert state.state == "°F"
+
 
 async def test_selecting_switches_the_grill(
     hass: HomeAssistant,

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -108,6 +108,27 @@ async def test_probe_native_value_and_unit(
 
 
 @pytest.mark.parametrize("model", ["PBV4PS2"])
+async def test_probe_absent_unit_flag_reads_as_fahrenheit(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+) -> None:
+    """Without isFahrenheit the probe value must be declared Fahrenheit.
+
+    Declaring Celsius made Home Assistant convert a raw 165 into 329 F for
+    the status-frame-only window.
+    """
+    entry = await mock_add_config_entry()
+    coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator.async_set_updated_data({"p1Temp": 165})
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.mygrill_mpc")
+    assert state is not None
+    assert state.state == "165"
+    assert state.attributes["unit_of_measurement"] == "\u00b0F"
+
+
+@pytest.mark.parametrize("model", ["PBV4PS2"])
 async def test_recipe_sensor_availability(
     hass: HomeAssistant,
     mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],


### PR DESCRIPTION
From the same audit. Four read sites defaulted a missing `isFahrenheit` to **Celsius** — `coordinator.grill_unit`, `climate.temperature_unit`, the probe sensor's unit, and the unit select — while pytboss's `_is_fahrenheit`, the default every setpoint is snapped with, reads it as **Fahrenheit**.

The window where this matters is real, not theoretical: on live parsing code the flag is emitted by the temperatures frame on all 20 boards but by the status frame on only 3 (the other 17 carry it commented out — a raw grep says otherwise, which is exactly how an earlier pass of mine wrongly cleared this). The board wipes each frame as it forwards commands, so a poll can land a status frame alone: a non-empty state without the key. For that window the entities presented Celsius units, Celsius bounds, and Celsius min/max — and a setpoint sent through them was snapped by pytboss against the Fahrenheit list. Ask for 100 °C, the board is sent 180 °F.

All four sites now default to Fahrenheit, matching the library, with the reasoning kept at the one place the divergence lived (`coordinator.grill_unit`'s docstring). Tests cover the window on each surface: climate's step reads 5.0, a raw probe 165 stays 165 °F instead of being converted as 329, and the select reports °F.

Verification: full suite green on Linux (148 passed, `python:3.14` container); ruff, `ruff format --check`, mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)