### PR TITLE
Make the services say what actually happened

### DIFF
--- a/custom_components/pitboss/services.py
+++ b/custom_components/pitboss/services.py
@@ -50,11 +50,23 @@ def _coordinator_for_device(
     device = dr.async_get(hass).async_get(device_id)
     if device is None:
         raise ServiceValidationError(f"Unknown device: {device_id}")
+    ours = False
     for entry_id in device.config_entries:
-        coordinator = hass.data.get(DOMAIN, {}).get(entry_id)
         entry = hass.config_entries.async_get_entry(entry_id)
-        if coordinator is not None and entry is not None:
+        if entry is None or entry.domain != DOMAIN:
+            continue
+        ours = True
+        coordinator = hass.data.get(DOMAIN, {}).get(entry_id)
+        if coordinator is not None:
             return coordinator, entry
+    if ours:
+        # The right target in the wrong state, which is not the caller's
+        # fault -- an entry mid-retry because the grill is off, or disabled.
+        # "Not a PitBoss grill" here sent people debugging their automation
+        # instead of their grill.
+        raise HomeAssistantError(
+            "The grill is not loaded yet; it may be off or still connecting."
+        )
     raise ServiceValidationError(f"Device {device_id} is not a PitBoss grill")
 
 
@@ -117,7 +129,19 @@ async def _async_start_grill(hass: HomeAssistant, call: ServiceCall) -> None:
         "Lighting the grill remotely. Make sure the lid is open and the burn "
         "pot is clear of unburned pellets."
     )
-    await coordinator.api.turn_grill_on()
+    try:
+        await coordinator.api.turn_grill_on()
+    except Unauthorized as ex:
+        # The same condition and the same answer as set_grill_password: the
+        # password Home Assistant holds is not the grill's, retrying cannot
+        # fix it, and the reauth flow is the only thing that can.
+        entry.async_start_reauth(hass)
+        raise HomeAssistantError(
+            "The grill rejected the password Home Assistant holds. "
+            "Enter the current one and try again."
+        ) from ex
+    except Exception as ex:
+        raise HomeAssistantError(f"Could not start the grill: {ex}") from ex
     await coordinator.async_request_refresh()
 
 

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -138,6 +138,83 @@ async def test_a_rejected_password_offers_reauth(
     assert [f for f in flows if f["context"].get("source") == "reauth"]
 
 
+async def test_start_grill_offers_reauth_on_a_rejected_password(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+    mock_pitboss: Mock,
+) -> None:
+    """The ignite command is authenticated like every other write.
+
+    A rejection gets the same answer set_grill_password already gives:
+    a clean error and the reauth flow, instead of an unknown error with
+    a traceback and no way to correct the password.
+    """
+    entry = await mock_add_config_entry()
+    hass.config_entries.async_update_entry(
+        entry, options={CONF_ENABLE_REMOTE_START: True}
+    )
+    mock_pitboss.is_connected.return_value = True
+    mock_pitboss.turn_grill_on.side_effect = Unauthorized("Unauthorized", 401)
+
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            DOMAIN,
+            "start_grill",
+            {"device_id": _device_id(hass)},
+            blocking=True,
+        )
+    await hass.async_block_till_done()
+
+    flows = hass.config_entries.flow.async_progress_by_handler(DOMAIN)
+    assert [f for f in flows if f["context"].get("source") == "reauth"]
+
+
+async def test_start_grill_wraps_other_failures(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+    mock_pitboss: Mock,
+) -> None:
+    """A failed ignite is a service error, not an unknown error."""
+    entry = await mock_add_config_entry()
+    hass.config_entries.async_update_entry(
+        entry, options={CONF_ENABLE_REMOTE_START: True}
+    )
+    mock_pitboss.is_connected.return_value = True
+    mock_pitboss.turn_grill_on.side_effect = TimeoutError("no answer")
+
+    with pytest.raises(HomeAssistantError, match="Could not start the grill"):
+        await hass.services.async_call(
+            DOMAIN,
+            "start_grill",
+            {"device_id": _device_id(hass)},
+            blocking=True,
+        )
+
+
+async def test_a_real_grill_that_is_not_loaded_is_named_as_such(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+) -> None:
+    """An entry mid-retry is the right target in the wrong state.
+
+    "Not a PitBoss grill" sent people debugging their automation instead
+    of their grill.
+    """
+    entry = await mock_add_config_entry()
+    device_id = _device_id(hass)
+    # The grill goes away: setup cleanup pops the coordinator, the device
+    # registry entry stays.
+    hass.data[DOMAIN].pop(entry.entry_id)
+
+    with pytest.raises(HomeAssistantError, match="not loaded"):
+        await hass.services.async_call(
+            DOMAIN,
+            "set_grill_password",
+            {"device_id": device_id, CONF_PASSWORD: "x"},
+            blocking=True,
+        )
+
+
 async def test_start_grill_refuses_unless_enabled(
     hass: HomeAssistant,
     mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],


### PR DESCRIPTION
Two error surfaces from the audit's minor queue, one file, one theme: the service layer answering with the wrong words.

**`start_grill` sent the ignite command unguarded.** It is authenticated like every other write, so a stale password surfaced as "Unknown error" with a traceback and no path to fix it — while its sibling `set_grill_password` already maps `Unauthorized` to the reauth flow plus a clean message. It now gets the identical treatment, and any other failure is wrapped as a service error naming the operation. Deliberately mirrored line for line rather than shared, so the two stay greppable next to their own gates.

**`_coordinator_for_device` called a real grill "not a PitBoss grill".** An entry mid-`ConfigEntryNotReady` (grill off) or disabled has no coordinator in `hass.data`, but its device and entry are right there — the right target in the wrong state, which is not the caller's fault. The resolver now distinguishes: a device with a PitBoss entry but no live coordinator gets "the grill is not loaded yet" as a `HomeAssistantError`; the validation error is reserved for devices that genuinely are not ours.

Three new tests: `start_grill` rejection opens reauth, other failures wrap with the operation named, and an unloaded-but-real grill is named as such.

Verification: full suite green on Linux (151 passed, `python:3.14` container — macOS cannot run the suite natively per AGENTS.md); ruff, `ruff format --check`, mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)