### PR TITLE
Find the grill, and let it be added

### DIFF
--- a/custom_components/pitboss/config_flow.py
+++ b/custom_components/pitboss/config_flow.py
@@ -81,7 +81,11 @@ class PitBossFlowHandler(ConfigFlow, domain=DOMAIN):
                 data_schema=vol.Schema({vol.Required(CONF_DEVICE_ID): str}),
             )
 
-        self._device_id = user_input[CONF_DEVICE_ID]
+        # Typed by hand, so normalized: real device IDs are the uppercase
+        # advertised name (prefix + MAC-derived hex), and the board lookup
+        # behind the next step compares names case-sensitively -- a pasted
+        # " pbl-3b22cd " aborted the flow for a fully supported grill.
+        self._device_id = user_input[CONF_DEVICE_ID].strip().upper()
         await self.async_set_unique_id(self._device_id.lower())
         self._abort_if_unique_id_configured()
         return await self.async_step_more_info()

--- a/custom_components/pitboss/manifest.json
+++ b/custom_components/pitboss/manifest.json
@@ -24,6 +24,10 @@
     },
     {
       "connectable": false,
+      "local_name": "PBC2-*"
+    },
+    {
+      "connectable": false,
       "local_name": "PBD-*"
     },
     {
@@ -44,7 +48,15 @@
     },
     {
       "connectable": false,
+      "local_name": "PBL3-*"
+    },
+    {
+      "connectable": false,
       "local_name": "PBM-*"
+    },
+    {
+      "connectable": false,
+      "local_name": "PBM2-*"
     },
     {
       "connectable": false,
@@ -60,7 +72,7 @@
     },
     {
       "connectable": false,
-      "local_name": "PBX1-*"
+      "local_name": "PBV2-*"
     }
   ],
   "codeowners": [

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -61,6 +61,33 @@ async def test_user_flow_shows_more_info_form(hass: HomeAssistant) -> None:
     assert result["step_id"] == "more_info"
 
 
+async def test_user_input_is_normalized(hass: HomeAssistant) -> None:
+    """A pasted lowercase or padded ID must not abort a supported grill.
+
+    Real IDs are the uppercase advertised name, and the board lookup is
+    case-sensitive -- " pbl-abc123 " used to hard-abort with unknown_grill.
+    """
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_DEVICE_ID: "  pbl-abc123  "}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "more_info"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_MODEL: "PBV4PS2",
+            CONF_PASSWORD: "",
+            CONF_PROTOCOL: PROTOCOL_WSS,
+        },
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_DEVICE_ID] == "PBL-ABC123"
+
+
 async def test_user_flow_creates_entry(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1,0 +1,36 @@
+"""The manifest's discovery matchers must track the pytboss catalogue."""
+
+import json
+import pathlib
+
+from pytboss import grills
+
+MANIFEST = (
+    pathlib.Path(__file__).parent.parent
+    / "custom_components"
+    / "pitboss"
+    / "manifest.json"
+)
+
+
+def _supported_boards() -> set[str]:
+    """Board names with at least one model the config flow would offer.
+
+    Enumerated through the private catalogue because nothing public lists
+    board names; `get_grills()` with no filter yields one entry per model,
+    which hides the older board of every dual-board pair.
+    """
+    names = {grill["control_board"]["name"] for grill in grills._get_grills().values()}
+    return {name for name in names if any(grills.get_grills(control_board=name))}
+
+
+def test_bluetooth_matchers_track_the_catalogue() -> None:
+    """Both drift directions have shipped: a matcher for a board whose only
+    model is unsupported walked users into an unknown_grill dead end, and
+    five supported boards had no matcher at all, so those grills were never
+    discovered. This fails the build when the catalogue moves again.
+    """
+    manifest = json.loads(MANIFEST.read_text())
+    matchers = {entry["local_name"] for entry in manifest["bluetooth"]}
+    expected = {f"{board}-*" for board in _supported_boards()}
+    assert matchers == expected


### PR DESCRIPTION
Two discovery-and-identity gaps from the audit, one theme: a supported grill failing to get in the door.

**Manual device-ID input stored whatever was typed.** Real IDs are the uppercase advertised name, and the board lookup behind the next step compares names case-sensitively — a pasted `" pbl-3b22cd "` hard-aborted the flow with `unknown_grill` for a fully supported grill, discarding the input. Manual entry is now stripped and uppercased; the Bluetooth path already arrives normalized, and the entry-data assertion tests pin the canonical form.

**The Bluetooth matcher list had drifted from the catalogue in both directions.** `PBX1-*` matched a board whose only model is in `UNSUPPORTED_MODELS`, so a discovered PBX1 always walked bluetooth → confirm → dead end. And four supported boards — PBC2, PBL3, PBM2, PBV2 — had no matcher at all (`PBM-*` does not glob `PBM2-…`), so those grills were never discovered and had to be typed in by hand. The list now matches the catalogue exactly.

The part with lasting value is the new `test_manifest.py`: it derives the expected matcher set from the pytboss catalogue and compares it to the manifest, so the next weekly definitions refresh that adds or retires a board fails the build instead of drifting silently. It caught its first mistake before this PR was ever pushed — PBVA looked eligible by raw parsing routine, but both its models are in `UNSUPPORTED_MODELS`, so it gets no matcher; I had it in the list until the test said no.

Verification: full suite green on Linux (150 passed, `python:3.14` container); ruff, `ruff format --check`, mypy clean. Note this edits `manifest.json`'s `bluetooth` array only — the `requirements` pin is untouched, per AGENTS.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)