### PR TITLE
Invalidate values a unit change leaves meaningless

### DIFF
--- a/custom_components/pitboss/climate.py
+++ b/custom_components/pitboss/climate.py
@@ -58,6 +58,7 @@ class GrillClimate(BaseEntity, ClimateEntity):
         )
         self._attr_unique_id = f"{self.entity_description.key}_{entry_unique_id}"
         self._pending_target: float | None = None
+        self._pending_unit: str | None = None
         self._cancel_settle: CALLBACK_TYPE | None = None
 
     async def async_added_to_hass(self) -> None:
@@ -158,9 +159,15 @@ class GrillClimate(BaseEntity, ClimateEntity):
     @callback
     def _handle_coordinator_update(self) -> None:
         if self._pending_target is not None:
-            reported = (self.coordinator.data or {}).get("grillSetTemp")
-            if reported is not None and float(reported) == self._pending_target:
+            # A unit change invalidates the number outright: 225 held from a
+            # Fahrenheit set must not be presented as 225 C for the rest of
+            # the settle window. The grill's own report wins immediately.
+            if self.temperature_unit != self._pending_unit:
                 self._pending_target = None
+            else:
+                reported = (self.coordinator.data or {}).get("grillSetTemp")
+                if reported is not None and float(reported) == self._pending_target:
+                    self._pending_target = None
         super()._handle_coordinator_update()
 
     async def async_set_temperature(self, **kwargs) -> None:
@@ -175,6 +182,7 @@ class GrillClimate(BaseEntity, ClimateEntity):
             wanted = min(accepted, key=lambda value: abs(value - asked))
         await self.coordinator.api.set_grill_temperature(int(wanted))
         self._pending_target = wanted
+        self._pending_unit = self.temperature_unit
         self.async_write_ha_state()
         # The MCU reports back within a couple of seconds; an immediate
         # refresh would only read the cleared status. A second set inside

--- a/custom_components/pitboss/coordinator.py
+++ b/custom_components/pitboss/coordinator.py
@@ -10,6 +10,7 @@ from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.util.unit_conversion import TemperatureConverter
 from pytboss.api import PitBoss
 from pytboss.exceptions import (
     GrillUnavailable,
@@ -63,7 +64,11 @@ class PitBossDataUpdateCoordinator(DataUpdateCoordinator[StateDict]):
         # small at process start, which 0.0 would read as "just tried".
         self._firmware_attempted_at: float | None = None
         # What the grill is holding, and what we are holding for it. See
-        # `probe_target` for why both exist.
+        # `probe_target` for why both exist. `restored_targets` is kept in
+        # Fahrenheit regardless of the grill's unit -- the same convention
+        # as the grill's own virtual-data store -- because these values
+        # outlive unit changes: one captured as "74" while the grill spoke
+        # Celsius must not be seeded as 74 F after the panel is flipped.
         self.probe_targets: dict[int, int] = {}
         self.restored_targets: dict[int, int] = {}
         self._targets_seeded = False
@@ -122,11 +127,33 @@ class PitBossDataUpdateCoordinator(DataUpdateCoordinator[StateDict]):
             return int(reported)
         if (target := self.probe_targets.get(probe_number)) is not None:
             return target
-        return self.restored_targets.get(probe_number)
+        if (held := self.restored_targets.get(probe_number)) is not None:
+            return self._from_fahrenheit(held)
+        return None
+
+    def _to_fahrenheit(self, temp: int) -> int:
+        """A grill-unit value, in the unit `restored_targets` is kept in."""
+        if self.grill_unit == UnitOfTemperature.FAHRENHEIT:
+            return temp
+        return round(
+            TemperatureConverter.convert(
+                temp, UnitOfTemperature.CELSIUS, UnitOfTemperature.FAHRENHEIT
+            )
+        )
+
+    def _from_fahrenheit(self, temp: int) -> int:
+        """A held Fahrenheit value, in the grill's current unit."""
+        if self.grill_unit == UnitOfTemperature.FAHRENHEIT:
+            return temp
+        return round(
+            TemperatureConverter.convert(
+                temp, UnitOfTemperature.FAHRENHEIT, UnitOfTemperature.CELSIUS
+            )
+        )
 
     async def async_set_probe_target(self, probe_number: int, temp: int) -> None:
-        """Set a probe's target, keeping it if the grill cannot take it yet."""
-        self.restored_targets[probe_number] = temp
+        """Set a probe's target, given in the grill's current unit."""
+        self.restored_targets[probe_number] = self._to_fahrenheit(temp)
         try:
             await self.api.set_probe_target(probe_number, temp)
         except UnsupportedOperation:
@@ -146,7 +173,7 @@ class PitBossDataUpdateCoordinator(DataUpdateCoordinator[StateDict]):
         and never reach the grill, which is the one case the restore exists
         for.
         """
-        self.restored_targets[probe_number] = temp
+        self.restored_targets[probe_number] = self._to_fahrenheit(temp)
         if probe_number not in self.probe_targets:
             self._targets_seeded = False
 
@@ -169,9 +196,12 @@ class PitBossDataUpdateCoordinator(DataUpdateCoordinator[StateDict]):
         # not know about goes over now. That is what makes setting a target on
         # a cold grill mean anything. A target the grill already has was set
         # elsewhere and wins.
-        for probe_number, temp in self.restored_targets.items():
+        for probe_number, held in self.restored_targets.items():
             if probe_number in self.probe_targets:
                 continue
+            # Converted at seeding time, into whatever unit the grill has
+            # *now* -- which may not be the unit it had at capture.
+            temp = self._from_fahrenheit(held)
             try:
                 await self.api.set_probe_target(probe_number, temp)
             except Exception as ex:  # noqa: BLE001

--- a/custom_components/pitboss/number.py
+++ b/custom_components/pitboss/number.py
@@ -79,6 +79,7 @@ class TargetProbeTemperature(BaseEntity, RestoreNumber):
         label = probe_label(coordinator.has_mpc, entity_description.probe_number)
         self._attr_name = f"{label} target"
         self._pending_value: int | None = None
+        self._pending_unit: str | None = None
         self._cancel_settle: CALLBACK_TYPE | None = None
 
     async def async_added_to_hass(self) -> None:
@@ -145,8 +146,11 @@ class TargetProbeTemperature(BaseEntity, RestoreNumber):
 
     @callback
     def _handle_coordinator_update(self) -> None:
+        # A unit change invalidates the held number; see the climate entity
+        # for the reasoning. The grill's own target wins either way.
         if self._pending_value is not None and (
-            self.coordinator.probe_target(self.entity_description.probe_number)
+            self.coordinator.grill_unit != self._pending_unit
+            or self.coordinator.probe_target(self.entity_description.probe_number)
             == self._pending_value
         ):
             self._pending_value = None
@@ -159,6 +163,7 @@ class TargetProbeTemperature(BaseEntity, RestoreNumber):
             self.entity_description.probe_number, target
         )
         self._pending_value = target
+        self._pending_unit = self.coordinator.grill_unit
         # Siblings read the coordinator too -- the target-reached sensor
         # follows the grill rather than this pending value.
         self.coordinator.async_update_listeners()

--- a/custom_components/pitboss/sensor.py
+++ b/custom_components/pitboss/sensor.py
@@ -76,6 +76,8 @@ RECIPE_ENTITY_DESCRIPTIONS = (
         key="recipeStep",
         name="Recipe Step",
         icon="mdi:format-list-numbered",
+        # A step index, not a measurement, for the same reason as above.
+        state_class=None,
     ),
 )
 

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -255,6 +255,42 @@ async def test_the_setpoint_holds_until_the_grill_confirms_it(
 
 
 @pytest.mark.parametrize("model", ["PBV4PS2"])
+async def test_a_unit_change_invalidates_the_held_setpoint(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+    mock_pitboss: Mock,
+) -> None:
+    """225 held from a Fahrenheit set must not be shown as 225 C.
+
+    If the grill's unit flips inside the settle window, the held number is
+    meaningless in the new unit; the grill's own report wins immediately
+    rather than at the end of the window.
+    """
+    entry = await mock_add_config_entry()
+    coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator.async_set_updated_data(
+        {"moduleIsOn": True, "isFahrenheit": True, "grillSetTemp": 250}
+    )
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        "climate",
+        "set_temperature",
+        {"entity_id": ENTITY_ID, "temperature": 300},
+        blocking=True,
+    )
+
+    coordinator.async_set_updated_data(
+        {"moduleIsOn": True, "isFahrenheit": False, "grillSetTemp": 121}
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    # 121 C converted for the imperial-unit test HA, not the stale 300.
+    assert state.attributes["temperature"] != 300.0
+
+
+@pytest.mark.parametrize("model", ["PBV4PS2"])
 async def test_an_unconfirmed_setpoint_expires_with_the_settle_window(
     hass: HomeAssistant,
     mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -225,3 +225,25 @@ async def test_a_success_resets_the_failure_pattern(
     with pytest.raises(UpdateFailed):
         await coordinator._async_update_data()
     assert coordinator.update_interval == ACTIVE_SCAN_INTERVAL
+
+
+async def test_a_restored_target_is_seeded_in_the_grills_current_unit(
+    coordinator: PitBossDataUpdateCoordinator, mock_pitboss: Mock
+) -> None:
+    """Captured as 74 while the grill spoke Celsius, seeded after a flip.
+
+    The held value is unit-fixed (Fahrenheit, like the grill's own store),
+    so it seeds as 165 F -- not as a raw 74 reinterpreted in the new unit.
+    """
+    coordinator.async_set_updated_data(StateDict(isFahrenheit=False))
+    coordinator.note_restored_target(2, 74)
+
+    # The panel is flipped to Fahrenheit before the grill is lit.
+    coordinator.async_set_updated_data(StateDict(isFahrenheit=True))
+    assert coordinator.probe_target(2) == 165
+
+    coordinator._api_started = True
+    mock_pitboss.is_connected.return_value = True
+    mock_pitboss.get_state.return_value = StateDict(moduleIsOn=True, isFahrenheit=True)
+    await coordinator._async_update_data()
+    mock_pitboss.set_probe_target.assert_awaited_once_with(2, 165)

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -351,3 +351,31 @@ async def test_the_grill_wins_once_it_confirms(
     state = hass.states.get("number.mygrill_mpc_target")
     assert state is not None
     assert state.state == "180"
+
+
+@pytest.mark.parametrize("model", ["PBV4PS2"])
+async def test_a_unit_change_invalidates_the_held_target(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+    mock_pitboss: Mock,
+) -> None:
+    """A target held from a Fahrenheit set is meaningless after a flip."""
+    entry = await mock_add_config_entry()
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator.async_set_updated_data({"moduleIsOn": True, "isFahrenheit": True})
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        "number",
+        "set_value",
+        {"entity_id": "number.mygrill_p2_target", "value": 165},
+        blocking=True,
+    )
+
+    coordinator.async_set_updated_data(
+        {"moduleIsOn": True, "isFahrenheit": False, "p2Target": 74}
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get("number.mygrill_p2_target")
+    assert state is not None
+    assert state.state != "165"

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -72,6 +72,15 @@ async def test_recipe_time_records_no_statistics(
     assert state.state == "90"
     assert "state_class" not in state.attributes
 
+    # The step index is not a measurement either.
+    coordinator.async_set_updated_data(
+        cast(StateDict, {"moduleIsOn": True, "recipeStep": 2})
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get("sensor.mygrill_recipe_step")
+    assert state is not None
+    assert "state_class" not in state.attributes
+
 
 @pytest.mark.parametrize("model", ["PB2180LK"])
 async def test_recipe_sensors_absent_when_unsupported(


### PR DESCRIPTION
Three related fixes from the audit's minor queue, one theme: numbers held past the frame that gave them meaning. Plus one statistics one-liner riding along, #359-style.

**The settle windows held their value through a grill unit flip.** Climate and the probe targets show the asked-for value until the grill confirms it — but a flip of the unit select (or the panel) inside the window left 225 from a Fahrenheit set presented as **225 °C**, above the entity's own bounds, until the window expired. The pending value now records the unit it was captured in and is dropped the moment the grill reports a different one — the grill's own report wins immediately instead of six seconds later.

**`restored_targets` stored bare numbers with no unit.** Captured in whatever unit the grill had at the time, seeded in whatever unit it had at ignition: 74 saved while the grill spoke Celsius became 74 °F after a panel flip. The held values are now unit-fixed to Fahrenheit — the same convention as the grill's own virtual-data store — converted at capture and again at seeding, so 74 °C seeds as 165 °F whatever happened to the panel in between.

**The rider:** `recipeStep` loses its `MEASUREMENT` state class for exactly the reason `recipeTime` did in #359 — long-term statistics of a step index mean nothing. Same orphaned-statistics repair note applies.

Tests cover each: a unit flip inside the window snaps climate and the probe target to the grill's report rather than the stale number; a target captured under Celsius reads and seeds as 165 after a flip to Fahrenheit (asserted on the actual `set_probe_target` call); and `recipe_step`'s state carries no `state_class`.

Verification: full suite green on Linux (151 passed, `python:3.14` container); ruff, `ruff format --check`, mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)