### PR TITLE
Target the oldest Python we admit, not the one we develop on

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -6,12 +6,22 @@
 # is not.
 #
 # `line-length` is what `ruff format` wraps to, so CI and a local run have to
-# agree on it. `target-version` was previously unset entirely: with no
-# pyproject.toml there was no `requires-python` for ruff to infer it from, so
-# version-dependent rules had nothing to work against. 3.14 matches
-# .python-version and Home Assistant's own floor.
+# agree on it.
+#
+# `target-version` is the OLDEST Python this integration has to run on, which
+# is not the one it is developed and tested on. hacs.json admits Home
+# Assistant 2025.1.0, and HA required Python 3.12 through the 2025 series and
+# 3.13 until 2026.7 -- so a user on 2026.6 is running 3.12 or 3.13 while CI
+# (which reads .python-version) runs 3.14.
+#
+# Set to 3.14 this was actively dangerous rather than merely imprecise:
+# `ruff format` rewrote `except (A, B):` into PEP 758's `except A, B:`, which
+# is a SyntaxError before 3.14. A formatter run could therefore produce a
+# module that fails to import for most users while every check stayed green,
+# and a config_flow that cannot import breaks setup for every protocol. This
+# nearly shipped once -- see #371.
 line-length    = 88
-target-version = "py314"
+target-version = "py312"
 
 # Deliberately no `[lint] select`: ruff 0.16's default rule set is much wider
 # than the `E4, E7, E9, F` the docs describe -- it includes BLE, B, S and

--- a/tests/test_python_floor.py
+++ b/tests/test_python_floor.py
@@ -1,0 +1,62 @@
+"""Every shipped module must parse on the oldest Python we admit.
+
+CI runs the version in `.python-version` (3.14), but `hacs.json` admits Home
+Assistant releases that run on older interpreters, and the integration is
+loaded by the user's Home Assistant rather than by CI. So syntax newer than
+the floor is invisible to every check and fatal on install: a module that
+cannot be imported takes the whole integration down, and `config_flow.py`
+failing to import breaks setup for every protocol, not just a new one.
+
+This nearly shipped once. With `target-version` set to 3.14, `ruff format`
+rewrote `except (A, B):` into PEP 758's `except A, B:` -- valid on 3.14, a
+SyntaxError before it -- and the reformatted file passed lint, format, mypy
+and the suite.
+
+The floor is read from `.ruff.toml` rather than repeated here, so the
+formatter's target and this check cannot drift apart.
+"""
+
+import ast
+import pathlib
+import re
+import tomllib
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).parent.parent
+COMPONENT = REPO_ROOT / "custom_components" / "pitboss"
+
+
+def _floor() -> tuple[int, int]:
+    """The (major, minor) `target-version` in `.ruff.toml`."""
+    config = tomllib.loads((REPO_ROOT / ".ruff.toml").read_text())
+    target = config["target-version"]
+    match = re.fullmatch(r"py(\d)(\d+)", target)
+    assert match, f"unrecognized target-version: {target}"
+    return int(match.group(1)), int(match.group(2))
+
+
+def test_the_floor_is_not_newer_than_the_home_assistant_version_we_admit():
+    """`hacs.json` admits 2025.1.0, whose Python floor is 3.12."""
+    major, minor = _floor()
+    assert (major, minor) <= (3, 12), (
+        f"target-version is py{major}{minor}, but hacs.json admits Home "
+        "Assistant 2025.1.0, which runs on Python 3.12. Raising this lets "
+        "the formatter emit syntax those users cannot import."
+    )
+
+
+@pytest.mark.parametrize(
+    "path",
+    sorted(COMPONENT.rglob("*.py")),
+    ids=lambda p: p.name,
+)
+def test_module_parses_on_the_oldest_supported_python(path: pathlib.Path):
+    try:
+        ast.parse(path.read_text(), filename=str(path), feature_version=_floor())
+    except SyntaxError as ex:
+        major, minor = _floor()
+        pytest.fail(
+            f"{path.relative_to(REPO_ROOT)} does not parse on Python "
+            f"{major}.{minor}: {ex.msg} (line {ex.lineno})"
+        )


### PR DESCRIPTION
Closes the trap I raised on #371.

## What was wrong

`.ruff.toml` set `target-version = "py314"`, with a comment stating that it "matches `.python-version` and Home Assistant's own floor." It matches `.python-version`. It does not match Home Assistant's floor, and `.python-version` is what **CI** runs, not what users run.

`hacs.json` admits Home Assistant **2025.1.0** — and Python only reached 3.14 in HA very recently:

| Home Assistant | Requires-Python |
|---|---|
| 2025.1.0 | >=3.12.0 |
| 2026.1.0 | >=3.13.2 |
| 2026.7.4 | **>=3.14.2** |

So a user on 2026.6 is running 3.12 or 3.13 while every check in this repo runs 3.14.

## Why that was dangerous rather than untidy

With the target at 3.14, `ruff format` **rewrites** `except (A, B):` into PEP 758's `except A, B:` — valid on 3.14, a `SyntaxError` before it. Reproduced against this repo's own config:

```
before:  except (ValueError, TypeError):
after:   except ValueError, TypeError:
         -> 3.12 SyntaxError: invalid syntax
```

A formatter run could therefore produce a module that fails to import for most users while lint, format, mypy and the whole suite stayed green. A `config_flow.py` that cannot import breaks setup for **every** protocol, not just the one someone was working on.

This is not hypothetical: it nearly shipped in #371, where @dknowles2 caught the syntax by parsing the blob under 3.9/3.12 and the suggested fix — parenthesising it — would have been rewritten straight back by the next `ruff format`.

## The fix

`target-version = "py312"`, matching the floor `hacs.json` admits. The rewrite stops and **the tree needs no reformatting** — `ruff check` and `ruff format --check` pass unchanged.

## Making it stick

A setting can be raised back, and the comment explaining why it was 3.14 was itself convincing. So `tests/test_python_floor.py`:

- parses every shipped module with `ast` at the floor, and
- fails if `target-version` is raised above what `hacs.json` admits.

The floor is **read from `.ruff.toml`** rather than repeated, so the formatter's target and the check cannot drift apart.

Verified it catches the real thing rather than passing vacuously — injecting `except ValueError, TypeError:` into `const.py`:

```
FAILED tests/test_python_floor.py::test_module_parses_on_the_oldest_supported_python[const.py]
1 failed, 14 passed
```

and restored afterwards.

## Worth knowing

**Unlike most of this suite, these tests run without a working Home Assistant test environment** — they only need `ast` and the two config files. So they work in environments where `KeyError: 'pitboss'` makes everything else unrunnable, which is where a syntax floor problem is most likely to be introduced.

`ruff check`, `ruff format --check`, `mypy .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)