### PR TITLE
Cover the probe-target restore and settle window

### DIFF
--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -1,13 +1,21 @@
 from collections.abc import Awaitable, Callable
+from datetime import timedelta
 from unittest.mock import Mock
 
 import pytest
 from conftest import get_entity
-from homeassistant.core import HomeAssistant
+from freezegun.api import FrozenDateTimeFactory
+from homeassistant.const import UnitOfTemperature
+from homeassistant.core import HomeAssistant, State
+from homeassistant.util import dt as dt_util
 from pytboss.exceptions import UnsupportedOperation
-from pytest_homeassistant_custom_component.common import MockConfigEntry
+from pytest_homeassistant_custom_component.common import (
+    MockConfigEntry,
+    async_fire_time_changed,
+    mock_restore_cache_with_extra_data,
+)
 
-from custom_components.pitboss.const import DOMAIN
+from custom_components.pitboss.const import DOMAIN, MCU_SETTLE_SECONDS
 from custom_components.pitboss.coordinator import PitBossDataUpdateCoordinator
 from custom_components.pitboss.number import TargetProbeTemperature
 
@@ -379,3 +387,228 @@ async def test_a_unit_change_invalidates_the_held_target(
     state = hass.states.get("number.mygrill_p2_target")
     assert state is not None
     assert state.state != "165"
+
+
+def _stored_target(entity_id: str, value: float, unit: str) -> tuple[State, dict]:
+    """A probe target as `RestoreNumber` would have written it at shutdown."""
+    return (
+        State(entity_id, str(value), {"unit_of_measurement": unit}),
+        {
+            "native_max_value": 250.0,
+            "native_min_value": 50.0,
+            "native_step": 1.0,
+            "native_unit_of_measurement": unit,
+            "native_value": value,
+        },
+    )
+
+
+@pytest.mark.parametrize("model", ["PBV4PS2"])
+async def test_a_restored_target_is_converted_into_the_grills_unit(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+    mock_pitboss: Mock,
+) -> None:
+    """The grill was switched to Fahrenheit while Home Assistant was down.
+
+    The restored number carries the unit it was displayed in; the coordinator
+    reads it as the grill's *current* unit. Skipping the conversion would file
+    a 71 °C target as 71 °F -- below the bottom of the probe range, and no
+    warmer than the meat starts out.
+    """
+    mock_restore_cache_with_extra_data(
+        hass,
+        [_stored_target("number.mygrill_p2_target", 71, UnitOfTemperature.CELSIUS)],
+    )
+
+    entry = await mock_add_config_entry()
+    coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+
+    # 71 °C is 159.8 °F, and the grill takes whole degrees.
+    assert coordinator.restored_targets[2] == 160
+
+
+@pytest.mark.parametrize("model", ["PBV4PS2"])
+async def test_a_restored_target_already_in_the_grills_unit_is_left_alone(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+) -> None:
+    """The common case: nothing changed over the restart."""
+    mock_restore_cache_with_extra_data(
+        hass,
+        [_stored_target("number.mygrill_p2_target", 165, UnitOfTemperature.FAHRENHEIT)],
+    )
+
+    entry = await mock_add_config_entry()
+    coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+
+    assert coordinator.restored_targets[2] == 165
+
+
+@pytest.mark.parametrize("model", ["PBV4PS2"])
+async def test_the_grills_own_target_wins_over_a_restored_one(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+    mock_pitboss: Mock,
+) -> None:
+    """A target set from the vendor's app while we were down is the truth."""
+    mock_restore_cache_with_extra_data(
+        hass,
+        [_stored_target("number.mygrill_p2_target", 165, UnitOfTemperature.FAHRENHEIT)],
+    )
+    mock_pitboss.get_probe_targets.return_value = {2: 190}
+    # The grill only holds targets while it is on, so `mock_add_config_entry`'s
+    # empty state would never read them. `side_effect` wins over the
+    # `return_value` that fixture assigns inside its callback.
+    mock_pitboss.get_state.side_effect = lambda: {
+        "moduleIsOn": True,
+        "isFahrenheit": True,
+    }
+
+    entry = await mock_add_config_entry()
+    coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+
+    assert 2 not in coordinator.restored_targets
+    assert coordinator.probe_target(2) == 190
+
+
+@pytest.mark.parametrize("model", ["PBV4PS2"])
+async def test_a_target_the_grill_never_takes_is_dropped_after_the_window(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+    mock_pitboss: Mock,
+) -> None:
+    """The slider shows what we asked for, but not indefinitely.
+
+    `native_value` holds the value we sent so the slider does not snap back
+    to the board's stale `pNTarget`. If the grill never reports it, holding
+    it forever would show a target the meat will never be cooked to.
+    """
+    entry = await mock_add_config_entry()
+    coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator.async_set_updated_data(
+        {"p1Target": 165, "p1Temp": 70, "isFahrenheit": True}
+    )
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        "number",
+        "set_value",
+        {"entity_id": "number.mygrill_mpc_target", "value": 180},
+        blocking=True,
+    )
+    state = hass.states.get("number.mygrill_mpc_target")
+    assert state is not None
+    assert state.state == "180"
+
+    # The grill keeps reporting the old target.
+    mock_pitboss.get_state.reset_mock()
+    async_fire_time_changed(
+        hass, dt_util.utcnow() + timedelta(seconds=MCU_SETTLE_SECONDS + 1)
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("number.mygrill_mpc_target")
+    assert state is not None
+    assert state.state == "165"
+    # The window asks the grill again rather than waiting out the poll.
+    assert mock_pitboss.get_state.await_count >= 1
+
+
+@pytest.mark.parametrize("model", ["PBV4PS2"])
+async def test_a_target_the_grill_takes_survives_the_window(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+    mock_pitboss: Mock,
+) -> None:
+    """The other half: the window must not undo a target that landed."""
+    entry = await mock_add_config_entry()
+    coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator.async_set_updated_data(
+        {"p1Target": 165, "p1Temp": 70, "isFahrenheit": True}
+    )
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        "number",
+        "set_value",
+        {"entity_id": "number.mygrill_mpc_target", "value": 180},
+        blocking=True,
+    )
+    mock_pitboss.get_state.side_effect = lambda: {
+        "p1Target": 180,
+        "p1Temp": 70,
+        "isFahrenheit": True,
+    }
+
+    async_fire_time_changed(
+        hass, dt_util.utcnow() + timedelta(seconds=MCU_SETTLE_SECONDS + 1)
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("number.mygrill_mpc_target")
+    assert state is not None
+    assert state.state == "180"
+
+
+@pytest.mark.parametrize("model", ["PBV4PS2"])
+async def test_a_second_set_replaces_the_window_rather_than_queueing(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+) -> None:
+    """The second set restarts the window; it does not inherit the first's.
+
+    The two sets are deliberately apart in time. If the first set's timer were
+    left armed, it would fire while the second value was only part-way through
+    its own window, dropping a target the grill may yet be about to report.
+    """
+    entry = await mock_add_config_entry()
+    coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator.async_set_updated_data(
+        {"p1Target": 165, "p1Temp": 70, "isFahrenheit": True}
+    )
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        "number",
+        "set_value",
+        {"entity_id": "number.mygrill_mpc_target", "value": 180},
+        blocking=True,
+    )
+
+    # Most of the way through the first window, but not through it.
+    freezer.tick(timedelta(seconds=MCU_SETTLE_SECONDS - 1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        "number",
+        "set_value",
+        {"entity_id": "number.mygrill_mpc_target", "value": 200},
+        blocking=True,
+    )
+
+    entity = get_entity(
+        hass, "number", "number.mygrill_mpc_target", TargetProbeTemperature
+    )
+    assert entity._pending_value == 200
+
+    # Past when the first window would have expired, inside the second.
+    freezer.tick(timedelta(seconds=2))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("number.mygrill_mpc_target")
+    assert state is not None
+    assert state.state == "200"
+
+    # The second window, having run its course, drops back to the grill.
+    freezer.tick(timedelta(seconds=MCU_SETTLE_SECONDS))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert entity._cancel_settle is None
+    state = hass.states.get("number.mygrill_mpc_target")
+    assert state is not None
+    assert state.state == "165"


### PR DESCRIPTION
Stacked on #383, which is what makes the suite runnable locally in the first place. Merge that first; this diff is the two test blocks only.

## Two behaviours had no test

Deleting either of these left the suite green:

| Code | What it does |
|---|---|
| `number.py` restore block | Restores a probe target across a restart, converting if the grill's unit changed while Home Assistant was down |
| `number.py` `_async_confirm` | The MCU settle window that stops the slider holding a target the grill never took |

## The restore case is the sharper one

`restored_targets` is kept in **Fahrenheit**; the entity converts the stored value into the grill's *current* unit before handing it over, and the coordinator converts from there. Both halves have to be right.

A target stored as `71 °C` and restored onto a grill now reporting Fahrenheit has to arrive as **160**. Without the conversion it is filed as `71 °F` — below the bottom of the probe range, and no warmer than the meat starts out. Nothing would have caught that.

## Mutation results

Every one of these survived before and fails now:

```
drop the restore unit conversion                    caught
restore: round -> truncate                          caught
restore: convert the wrong way                      caught
restore: ignore the grill's own target              caught
settle: never refresh                               caught
settle: keep holding the value                      caught
settle: never arm the timer                         caught
settle: queue a second timer instead of replacing   caught
```

`number.py` goes from **84% to 99%** branch coverage; the module total from 94% to 95%.

## One thing worth knowing about the settle tests

The first version of the "second set replaces the window" test passed but **did not discriminate** — the mutation that queues a second timer instead of cancelling the first still survived it. The timers are armed against loop time, so passing a future datetime to `async_fire_time_changed` does not actually move the two windows apart: both expire on the same fire, and a queued second timer looks identical to a replaced one.

It uses `freezer` now, and catches the mutation. Worth remembering for any future timer test in this repo.

## Not in this PR

`climate.py`'s `min_temp`/`max_temp` are still uncovered, and are **not** a test gap — see the issue I am filing alongside this. Those lines are unreachable for every grill in the catalogue, so a test would have to build a spec that does not exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)