### PR TITLE
Call entities entities, and drop a dead annotation

### DIFF
--- a/custom_components/pitboss/climate.py
+++ b/custom_components/pitboss/climate.py
@@ -32,7 +32,7 @@ from .entity import BaseEntity
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ):
-    """Setup binary_sensor platform."""
+    """Setup climate platform."""
     coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
     assert entry.unique_id is not None
     async_add_entities([GrillClimate(coordinator, entry.unique_id)])

--- a/custom_components/pitboss/entity.py
+++ b/custom_components/pitboss/entity.py
@@ -10,7 +10,6 @@ from .coordinator import PitBossDataUpdateCoordinator
 class BaseEntity(CoordinatorEntity[PitBossDataUpdateCoordinator]):
     """Base entity class."""
 
-    _device_id: str
     _attr_has_entity_name = True
 
     def __init__(

--- a/custom_components/pitboss/light.py
+++ b/custom_components/pitboss/light.py
@@ -16,13 +16,13 @@ from .entity import BaseEntity
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, entry: ConfigEntry, async_add_devices: AddEntitiesCallback
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ):
     """Setup light platform."""
     coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
     assert entry.unique_id is not None
     if coordinator.api.spec.has_lights:
-        async_add_devices([GrillLight(coordinator, entry.unique_id)])
+        async_add_entities([GrillLight(coordinator, entry.unique_id)])
 
 
 class GrillLight(BaseEntity, LightEntity):

--- a/custom_components/pitboss/number.py
+++ b/custom_components/pitboss/number.py
@@ -42,7 +42,7 @@ PROBE_DESCRIPTIONS = (
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, entry: ConfigEntry, async_add_devices: AddEntitiesCallback
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ):
     """Setup number platform."""
     coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
@@ -56,7 +56,7 @@ async def async_setup_entry(
         if description.probe_number <= probe_count
     ]
     if entities:
-        async_add_devices(entities)
+        async_add_entities(entities)
 
 
 class TargetProbeTemperature(BaseEntity, RestoreNumber):

--- a/custom_components/pitboss/sensor.py
+++ b/custom_components/pitboss/sensor.py
@@ -87,7 +87,7 @@ type PBSensorEntityDescription = (
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, entry: ConfigEntry, async_add_devices: AddEntitiesCallback
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ):
     """Setup sensor platform."""
     coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
@@ -104,7 +104,7 @@ async def async_setup_entry(
             entities.append(
                 RecipeSensor(coordinator, entry.unique_id, entity_description)
             )
-    async_add_devices(entities)
+    async_add_entities(entities)
 
 
 class BaseSensorEntity(BaseEntity, SensorEntity):

--- a/custom_components/pitboss/switch.py
+++ b/custom_components/pitboss/switch.py
@@ -19,15 +19,15 @@ from .entity import BaseEntity
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, entry: ConfigEntry, async_add_devices: AddEntitiesCallback
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ):
-    """Setup sensor platform."""
+    """Setup switch platform."""
     coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
     assert entry.unique_id is not None
     entities: list[BaseSwitchEntity] = [PowerSwitch(coordinator, entry.unique_id)]
     if "turn-primer-motor-on" in coordinator.api.spec.control_board.commands:
         entities.append(PrimerSwitch(coordinator, entry.unique_id))
-    async_add_devices(entities)
+    async_add_entities(entities)
 
 
 class BaseSwitchEntity(BaseEntity, SwitchEntity):


### PR DESCRIPTION
Three small things found in a readability pass. No behaviour change.

**`async_add_devices` → `async_add_entities`.** Both names were in use for the same callback, split four files each way — `light`, `number`, `switch`, `sensor` one way; `binary_sensor`, `button`, `select`, `climate` the other. Home Assistant calls it `async_add_entities`, and that is also what it is: nothing here adds a device.

**Two copy-pasted docstrings.** `async_setup_entry` in `switch.py` announced itself as the sensor platform, and the one in `climate.py` as the binary_sensor platform.

**`BaseEntity._device_id`** was declared and never assigned or read. The name does live on the config flow, where it means something else, so the annotation reads as a link between the two that does not exist.

159 tests pass, `ruff check`, `ruff format --check` and `mypy .` clean.

> Verified locally by borrowing the conftest fix from #383 — this branch is off `main`, where the suite still cannot run on macOS. Nothing from that PR is in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)