### PR TITLE
Name the grill in the discovery row

### DIFF
--- a/custom_components/pitboss/translations/en.json
+++ b/custom_components/pitboss/translations/en.json
@@ -1,6 +1,7 @@
 {
   "title": "PitBoss",
   "config": {
+    "flow_title": "{name}",
     "abort": {
       "already_configured": "Grill is already configured",
       "reconfigure_successful": "Re-configuration was successful",

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,3 +1,5 @@
+import json
+import pathlib
 import threading
 from unittest.mock import Mock, patch
 
@@ -639,3 +641,40 @@ async def test_a_host_is_not_required_for_other_protocols(hass: HomeAssistant) -
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["data"][CONF_HOST] == ""
+
+
+async def test_the_discovery_row_names_the_grill(hass: HomeAssistant) -> None:
+    """A discovered grill must be identifiable before it is set up.
+
+    `async_step_bluetooth` sets a `name` title placeholder, but nothing
+    consumed it: with no `flow_title` in the translations the frontend falls
+    back to the integration's own title, so two grills waiting to be
+    configured were two rows both reading "PitBoss". Asserted together
+    because the placeholder and the template that renders it are only
+    correct as a pair -- either one alone silently produces the same
+    fallback.
+    """
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_BLUETOOTH},
+        data=_bluetooth_service_info("PBL-ABC123"),
+    )
+    flow = next(
+        f
+        for f in hass.config_entries.flow.async_progress()
+        if f["flow_id"] == result["flow_id"]
+    )
+    placeholders = flow["context"]["title_placeholders"]
+    assert placeholders == {"name": "PBL-ABC123"}
+
+    translations = json.loads(
+        (
+            pathlib.Path(__file__).parent.parent
+            / "custom_components"
+            / "pitboss"
+            / "translations"
+            / "en.json"
+        ).read_text()
+    )
+    flow_title = translations["config"]["flow_title"]
+    assert flow_title.format(**placeholders) == "PBL-ABC123"


### PR DESCRIPTION
`async_step_bluetooth` sets a title placeholder for the discovered grill:

```py
self.context["title_placeholders"] = {"name": self._device_id}
```

but nothing consumes it — `en.json` has no `flow_title`, so the frontend falls back to the integration's own title. Two grills waiting to be configured are two rows both reading "PitBoss", with nothing to tell them apart. This integration discovers by Bluetooth, so more than one pending at once is the ordinary case for anyone with a second grill.

One line in `en.json`. The test asserts the placeholder and the template that renders it *together*, because either one alone silently produces the same fallback — the pair is the invariant, not each half.

197 passed, ruff / ruff format / mypy clean. Verified the test fails without the translation key (KeyError), not just passes with it.

---

## A question rather than a change: `iot_class`

The manifest declares `local_push`. That was exactly right when Bluetooth was the only transport; with three it describes one of them:

| protocol | local or cloud | push or poll |
|---|---|---|
| `ble` | local | push — `subscribe_state` over notifications |
| `wss` (**`DEFAULT_PROTOCOL`**) | **cloud** | push — `subscribe_state` over the socket |
| `local` | local | **poll** — no push on the local endpoint, which is what motivated adaptive polling |

No single value covers all three, and the field takes one. Worth noting the default is `wss`, so the declared class does not describe the path a user gets unless they change it.

I have not touched it here — it is repo-level metadata, it shows in the HACS listing, and picking between `local_push` and `cloud_push` is a judgment about which users the manifest should describe rather than a bug with a right answer. Happy to send whichever you prefer as a one-line follow-up, or to leave it alone if the Bluetooth-first reading is the intended one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)