### PR TITLE
Bump pytboss to 2026.8.5

### DIFF
--- a/custom_components/pitboss/coordinator.py
+++ b/custom_components/pitboss/coordinator.py
@@ -385,11 +385,14 @@ class PitBossDataUpdateCoordinator(DataUpdateCoordinator[StateDict]):
                 raise UpdateFailed("Grill not connected")
             # The local HTTP transport recovers only by being spoken to, and
             # a poll is the only speaker. `connect()` is its reachability
-            # probe, so success here means connected again. Calling this for
-            # the other transports would not be safe: `connect()` on a
-            # websocket mid-backoff starts a second receive loop on the
-            # pinned pytboss (serialized upstream in pytboss#572, not yet
-            # released).
+            # probe, so success here means connected again. Still gated on
+            # the protocol rather than done for everyone: the other two
+            # transports own their reconnect, and a poll reaching into that
+            # races whatever they already have in flight. It used to be
+            # unsafe outright -- `connect()` on a websocket mid-backoff
+            # started a second receive loop -- which pytboss#572 fixed by
+            # serializing the lifecycle, so this is now a question of who
+            # owns reconnection rather than of corruption.
             self.logger.debug("Reconnecting to the grill")
             await self._start_api()
 

--- a/custom_components/pitboss/manifest.json
+++ b/custom_components/pitboss/manifest.json
@@ -89,7 +89,7 @@
     "pytboss"
   ],
   "requirements": [
-    "pytboss==2026.8.4"
+    "pytboss==2026.8.5"
   ],
   "version": "0000.0.0"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ mypy==2.3.0
 pip>=26.2
 pyserial-asyncio==0.6
 pyserial==3.5
-pytboss==2026.8.4
+pytboss==2026.8.5
 pytest_homeassistant_custom_component==0.13.348
 ruff==0.16.1
 serialx==1.8.2


### PR DESCRIPTION
Both pins, one PR, per AGENTS.md — `requirements.txt` is what CI installs, `manifest.json` is what Home Assistant installs for users. Moving only one is the silent failure that section exists for.

```
requirements.txt:9                        pytboss==2026.8.5
custom_components/pitboss/manifest.json:92 "pytboss==2026.8.5"
```

## What users actually get

2026.8.5 is the first release since 2026.8.4 and carries **30 commits**. The ones that change behaviour here:

| Change | Effect |
|---|---|
| `ftoc(null)` sentinel fix | A disconnected probe reads unavailable, not **-18 °C** |
| Unconverted fields (PBA/PBE/PBT) | Temperatures follow the frame's unit instead of sitting in Fahrenheit beside converted siblings |
| PBVA `p4Temp` dropped | The grill setpoint stops being reported as probe 4 |
| Truncated-frame rejection | A short frame is rejected instead of parsed into a partial state |
| `ControlBoard.emits()` | The primitive #388 needs |

The first is the one a user would notice. On boards that convert in their own routine, the 960 "disconnected" sentinel went through `ftoc`, and JS coerced the resulting `null` to `0` — so an empty probe port reported a plausible-looking freezing temperature on every Celsius grill.

## Verified against the release, not the lockfile

Installed the real thing rather than trusting resolution:

```
installed pytboss: 2026.8.5
emits() available: True | emits(erL) = True
HttpConnection exported: True
```

And checked the sentinel fix end to end on a converting board (PB1150PS3, p1 unplugged, p2 at 165 °F):

```
F frame -> p1Temp=None (unplugged)  p2Temp=165
C frame -> p1Temp=None (unplugged)  p2Temp=73
```

`197 passed`, `ruff check`, `ruff format --check`, `mypy .` all clean, against 2026.8.5 installed locally.

## One comment this release makes untrue

`coordinator.py`'s reconnect-on-poll gate said calling `connect()` on a websocket would start a second receive loop *"on the pinned pytboss (serialized upstream in pytboss#572, not yet released)"*. It is released now.

The gate itself is still right, so the comment is rewritten rather than deleted — the reason is now that the other two transports own their reconnect and a poll reaching into that races what they already have in flight, not that it corrupts anything. Left as-is it would have read as a live hazard that no longer exists, which is the sort of thing that gets "simplified" away later.

## Not touched

`docs/SUPPORTED_GRILLS.md` is generated — `update-grill-docs.yml` regenerates and commits it when the `pytboss==` pin in `requirements.txt` changes, so it should not appear in a hand-authored diff.

## Sequencing

This unblocks trailro's #388 fix, which is written against `emits()` and was explicitly waiting on a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)