### PR TITLE
Create the error sensors a board actually reports

### DIFF
--- a/custom_components/pitboss/binary_sensor.py
+++ b/custom_components/pitboss/binary_sensor.py
@@ -120,7 +120,16 @@ async def async_setup_entry(
     coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
     entities: list[BinarySensorEntity] = []
     assert entry.unique_id is not None
+    board = coordinator.api.spec.control_board
     for entity_description in ENTITY_DESCRIPTIONS:
+        # Not every board reports every flag: PBM and PBM2 have no `erL` in
+        # either parsing routine, so their "Startup error" sensor was created
+        # and then sat unknown for the life of the entry. Asked of the board
+        # rather than gated on a list of names here, so a definitions refresh
+        # that adds or drops a field is followed without a change in this
+        # repo.
+        if not board.emits(entity_description.key):
+            continue
         entities.append(BinarySensor(coordinator, entry.unique_id, entity_description))
     entities.append(ConnectivitySensor(coordinator, entry.unique_id))
     entities.append(MeatProbeControlSensor(coordinator, entry.unique_id))

--- a/custom_components/pitboss/binary_sensor.py
+++ b/custom_components/pitboss/binary_sensor.py
@@ -11,8 +11,9 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntityDescription,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import EntityCategory
+from homeassistant.const import EntityCategory, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN, probe_label
@@ -121,6 +122,7 @@ async def async_setup_entry(
     entities: list[BinarySensorEntity] = []
     assert entry.unique_id is not None
     board = coordinator.api.spec.control_board
+    registry = er.async_get(hass)
     for entity_description in ENTITY_DESCRIPTIONS:
         # Not every board reports every flag: PBM and PBM2 have no `erL` in
         # either parsing routine, so their "Startup error" sensor was created
@@ -129,6 +131,18 @@ async def async_setup_entry(
         # that adds or drops a field is followed without a change in this
         # repo.
         if not board.emits(entity_description.key):
+            # The affected grills are the ones already running, so the row is
+            # already in the registry. Home Assistant keeps a row whose entity
+            # stops being created and renders it as unavailable, which would
+            # turn "permanently unknown" into "permanently unavailable" for
+            # exactly the users this is meant to help. Removed here so the
+            # entity goes away on the next start rather than having to be
+            # deleted by hand.
+            unique_id = f"{entity_description.key}_{entry.unique_id}"
+            if stale := registry.async_get_entity_id(
+                Platform.BINARY_SENSOR, DOMAIN, unique_id
+            ):
+                registry.async_remove(stale)
             continue
         entities.append(BinarySensor(coordinator, entry.unique_id, entity_description))
     entities.append(ConnectivitySensor(coordinator, entry.unique_id))

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock
 import pytest
 from conftest import get_entity
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.pitboss.binary_sensor import (
@@ -295,3 +296,41 @@ async def test_a_flag_the_board_never_reports_gets_no_entity(
     # The rest still arrive: this must not thin out the platform.
     assert hass.states.get(_entity_id("Fan error")) is not None
     assert hass.states.get(_entity_id("Igniter error")) is not None
+
+
+@pytest.mark.parametrize("model", ["PB850CS2"])
+async def test_the_stale_row_from_an_earlier_release_is_removed(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+) -> None:
+    """The boards this affects are the ones already running.
+
+    Their `startup_error` row is already in the registry, and Home Assistant
+    keeps a row whose entity stops being created -- rendering it as
+    unavailable rather than dropping it, with manual deletion the only way
+    out. Not creating the entity alone would turn "permanently unknown" into
+    "permanently unavailable" for exactly the installs this is meant to fix,
+    so the row is removed too. Seeding it is the only way this path runs.
+    """
+    registry = er.async_get(hass)
+    mock_config_entry.add_to_hass(hass)
+    stale = registry.async_get_or_create(
+        "binary_sensor",
+        DOMAIN,
+        f"erL_{mock_config_entry.unique_id}",
+        suggested_object_id="mygrill_startup_error",
+        config_entry=mock_config_entry,
+    )
+    assert registry.async_get(stale.entity_id) is not None
+
+    await mock_add_config_entry()
+
+    assert registry.async_get(stale.entity_id) is None
+    # A flag the board does report keeps its row.
+    assert (
+        registry.async_get_entity_id(
+            "binary_sensor", DOMAIN, f"fanErr_{mock_config_entry.unique_id}"
+        )
+        is not None
+    )

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -15,8 +15,6 @@ from custom_components.pitboss.binary_sensor import (
 from custom_components.pitboss.const import DOMAIN
 from custom_components.pitboss.coordinator import PitBossDataUpdateCoordinator
 
-pytestmark = pytest.mark.parametrize("model", ["PBV4PS2"])
-
 
 def _entity_id(name: str) -> str:
     return f"binary_sensor.mygrill_{name.lower().replace(' ', '_')}"
@@ -27,6 +25,7 @@ def _entity_id(name: str) -> str:
 PROBE_ERROR_NAMES = {"err1": "MPC error", "err2": "P2 error", "err3": "P3 error"}
 
 
+@pytest.mark.parametrize("model", ["PBV4PS2"])
 async def test_creates_all_entities(
     hass: HomeAssistant,
     mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
@@ -44,6 +43,7 @@ async def test_creates_all_entities(
         assert hass.states.get(entity_id) is not None, entity_id
 
 
+@pytest.mark.parametrize("model", ["PBV4PS2"])
 async def test_is_on_no_data(
     hass: HomeAssistant,
     mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
@@ -57,6 +57,7 @@ async def test_is_on_no_data(
     assert entity.is_on is None
 
 
+@pytest.mark.parametrize("model", ["PBV4PS2"])
 async def test_is_on_with_data(
     hass: HomeAssistant,
     mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
@@ -73,6 +74,7 @@ async def test_is_on_with_data(
     assert auger.state == "off"
 
 
+@pytest.mark.parametrize("model", ["PBV4PS2"])
 async def test_fan_and_igniter_report_their_state(
     hass: HomeAssistant,
     mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
@@ -91,6 +93,7 @@ async def test_fan_and_igniter_report_their_state(
     assert igniter.state == "off"
 
 
+@pytest.mark.parametrize("model", ["PBV4PS2"])
 async def test_connectivity_reports_offline_instead_of_vanishing(
     hass: HomeAssistant,
     mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
@@ -114,6 +117,7 @@ async def test_connectivity_reports_offline_instead_of_vanishing(
     assert state.state == "off"
 
 
+@pytest.mark.parametrize("model", ["PBV4PS2"])
 async def test_connectivity_follows_the_grill_not_just_the_socket(
     hass: HomeAssistant,
     mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
@@ -142,6 +146,7 @@ async def test_connectivity_follows_the_grill_not_just_the_socket(
     assert state.state == "off"
 
 
+@pytest.mark.parametrize("model", ["PBV4PS2"])
 async def test_a_target_reached_sensor_per_probe(
     hass: HomeAssistant,
     mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
@@ -153,6 +158,7 @@ async def test_a_target_reached_sensor_per_probe(
     assert hass.states.get(_entity_id("P3 target reached")) is None
 
 
+@pytest.mark.parametrize("model", ["PBV4PS2"])
 async def test_target_reached_follows_the_probe(
     hass: HomeAssistant,
     mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
@@ -173,6 +179,7 @@ async def test_target_reached_follows_the_probe(
     assert state.state == "on"
 
 
+@pytest.mark.parametrize("model", ["PBV4PS2"])
 async def test_target_reached_is_off_rather_than_unknown(
     hass: HomeAssistant,
     mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
@@ -201,6 +208,7 @@ async def test_target_reached_is_off_rather_than_unknown(
     assert state.state == "off"
 
 
+@pytest.mark.parametrize("model", ["PBV4PS2"])
 async def test_target_reached_uses_a_target_the_grill_does_not_report(
     hass: HomeAssistant,
     mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
@@ -223,6 +231,7 @@ async def test_target_reached_uses_a_target_the_grill_does_not_report(
     assert state.state == "on"
 
 
+@pytest.mark.parametrize("model", ["PBV4PS2"])
 async def test_meat_probe_control_sensor(
     hass: HomeAssistant,
     mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
@@ -234,6 +243,7 @@ async def test_meat_probe_control_sensor(
     assert state.state == "on"
 
 
+@pytest.mark.parametrize("model", ["PBV4PS2"])
 async def test_meat_probe_control_sensor_without_a_control_port(
     hass: HomeAssistant,
     mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
@@ -249,6 +259,7 @@ async def test_meat_probe_control_sensor_without_a_control_port(
     assert state.state == "off"
 
 
+@pytest.mark.parametrize("model", ["PBV4PS2"])
 async def test_meat_probe_control_stays_available_while_disconnected(
     hass: HomeAssistant,
     mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
@@ -264,3 +275,23 @@ async def test_meat_probe_control_stays_available_while_disconnected(
     state = hass.states.get(_entity_id("Meat probe control"))
     assert state is not None
     assert state.state == "on"
+
+
+@pytest.mark.parametrize("model", ["PB850CS2"])
+async def test_a_flag_the_board_never_reports_gets_no_entity(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+) -> None:
+    """PBM2 has no `erL` in either parsing routine.
+
+    The sensor was created anyway and sat unknown for the life of the entry,
+    since the merged state never carries the key. `erL` is the only one of
+    these flags that is not universal today; the gate is written against
+    what the board reports rather than against that fact, so a definitions
+    refresh is followed without a change here.
+    """
+    await mock_add_config_entry()
+    assert hass.states.get(_entity_id("Startup error")) is None
+    # The rest still arrive: this must not thin out the platform.
+    assert hass.states.get(_entity_id("Fan error")) is not None
+    assert hass.states.get(_entity_id("Igniter error")) is not None


### PR DESCRIPTION
Fixes #388.

PBM and PBM2 have no `erL` in either parsing routine, so their "Startup error" sensor was created and then sat unknown for the life of the entry — the merged state never carries the key. Twenty models across the two boards.

```py
board = coordinator.api.spec.control_board
...
if not board.emits(entity_description.key):
    continue
```

Asked of the board rather than gated on a list of board names here, so a definitions refresh that adds or drops a field is followed without a change in this repo. `emits()` is dknowles2/pytboss#599, released in `2026.8.5` — already pinned in both files by #390, so nothing to bump here.

`erL` is the only one of these twelve flags that is not universal today; the sweep behind #388 found no other mismatch, and `primeState` — the other non-universal key — backs the primer switch, which `switch.py` already gates on the command being declared.

## Notes

- **The module-level `model` parametrization had to go.** The file now needs a second board, and pytest rejects a per-test `parametrize` for an argument already parametrized at module level. Converted to per-test decorators, which is what `test_sensor.py`, `test_switch.py`, `test_light.py` and `test_number.py` already do — the module-level mark in this file was the outlier. No test changed meaning; every existing one still runs against `PBV4PS2`.
- The new test also asserts two sensors that *should* exist still do, so a gate that thins out the platform fails rather than passes quietly.

198 passed, ruff / ruff format / mypy clean. Verified the test fails with the gate removed, not just passes with it in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)