### PR TITLE
Add unit-overridable chamber entities alongside the climate one

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ dependency is updated.
 | `button` | Restart the controller; request fast updates |
 | `climate` | Grill temperature and HVAC action; turn off only (safety) |
 | `light` | The grill's built-in light, if the model has one |
-| `number` | A target temperature for every probe the grill supports |
+| `number` | A target temperature for every probe the grill supports, and an optional grill setpoint |
 | `select` | The temperature unit the grill itself displays |
-| `sensor` | Probe temperatures, recipe progress, firmware version, controller uptime and free memory |
+| `sensor` | Probe temperatures, recipe progress, firmware version, controller uptime and free memory, and an optional grill temperature |
 | `switch` | Grill module power (turn off only) and the primer motor |
 
 ### Entity details
@@ -59,6 +59,7 @@ dependency is updated.
 - **Climate (`Grill temperature`):** Current and target temperature, plus HVAC action. Target temperatures snap to the values the control board actually accepts — the board silently ignores anything else. Setting HVAC mode to `off` turns the grill off and leaves the setpoint alone.
 - **Sensor (`MPC`/`P2`–`P4`, or `Probe 1`–`Probe 4`):** Probe temperatures in the grill's current unit. On grills with a meat probe control port, probe 1 is labelled `MPC` to match what is printed by the socket; other grills keep numbered names. Only as many probes as the grill has are enabled.
 - **Number (`… target`):** A target for every probe the board supports, not just the first two. Targets can be set while the probe is unplugged and while the grill is off — they are held and sent when the grill comes on.
+- **Sensor (`Chamber temperature`) and number (`Chamber setpoint`), both disabled by default:** The same reading and the same control the climate entity offers, in a shape you can override the unit on. Home Assistant resolves a per-entity unit for `sensor` and `number` entities but not for `climate` ones, so if you want the grill in °F while the rest of your Home Assistant is in °C — or the other way round — enable these two and set the unit under each entity's own settings. The climate entity stays whatever you do: it is what voice assistants control and what reports HVAC action. Both controls write through the same place, so moving one moves the other straight away.
 - **Binary sensor (`… target reached`):** One per probe, comparing the probe against its target.
 - **Binary sensor (`Connectivity`):** Stays available so it can report *disconnected*, rather than vanishing along with everything else.
 - **Binary sensor (`Meat probe control`):** Whether the grill has a control port at all.

--- a/custom_components/pitboss/__init__.py
+++ b/custom_components/pitboss/__init__.py
@@ -212,5 +212,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN].pop(
             entry.entry_id
         )
+        # The coordinator holds a settle timer of its own, which nothing else
+        # unschedules on unload.
+        await coordinator.async_shutdown()
         await coordinator.api.stop()
     return unloaded

--- a/custom_components/pitboss/climate.py
+++ b/custom_components/pitboss/climate.py
@@ -13,11 +13,10 @@ from homeassistant.components.climate.const import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
-from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.event import async_call_later
 
-from .const import DOMAIN, LOGGER, MCU_SETTLE_SECONDS
+from .const import DOMAIN, GRILL_CELSIUS_STEP, GRILL_FAHRENHEIT_STEP, LOGGER
 from .coordinator import PitBossDataUpdateCoordinator
 from .entity import BaseEntity
 
@@ -50,23 +49,6 @@ class GrillClimate(BaseEntity, ClimateEntity):
             name="Grill temperature",
         )
         self._attr_unique_id = f"{self.entity_description.key}_{entry_unique_id}"
-        self._pending_target: float | None = None
-        self._pending_unit: str | None = None
-        self._cancel_settle: CALLBACK_TYPE | None = None
-
-    async def async_added_to_hass(self) -> None:
-        """Register the one removal callback this entity needs."""
-        await super().async_added_to_hass()
-        # Registered once rather than per set: `async_on_remove` only
-        # appends, so re-registering would grow the list for the life of
-        # the entity.
-        self.async_on_remove(self._cancel_pending_settle)
-
-    @callback
-    def _cancel_pending_settle(self) -> None:
-        if self._cancel_settle is not None:
-            self._cancel_settle()
-            self._cancel_settle = None
 
     @property
     def _accepted_setpoints(self) -> list[float]:
@@ -86,9 +68,9 @@ class GrillClimate(BaseEntity, ClimateEntity):
     @property
     def target_temperature_step(self) -> float:
         if self.temperature_unit == UnitOfTemperature.FAHRENHEIT:
-            return 5.0
+            return float(GRILL_FAHRENHEIT_STEP)
         else:
-            return 1.0
+            return float(GRILL_CELSIUS_STEP)
 
     @property
     def min_temp(self) -> float:
@@ -130,66 +112,17 @@ class GrillClimate(BaseEntity, ClimateEntity):
     def target_temperature(self) -> float | None:
         """The grill's setpoint, or the one just asked for.
 
-        Shows what was asked until the grill confirms it: the board wipes
-        its cached status the moment it forwards a command to the MCU, so
-        the next poll still carries the old setpoint and the slider would
-        appear to snap back. The select and the probe targets already work
-        this way; the climate card was the one control that did not.
+        Held by the coordinator rather than here: the grill setpoint number
+        is a second control over the same setting, and a value held by
+        whichever control happened to be used would leave the other showing
+        the previous setpoint for the length of the settle window.
         """
-        if self._pending_target is not None:
-            return self._pending_target
-        if (data := self.coordinator.data) and (
-            temp := data.get("grillSetTemp")
-        ) is not None:
-            return float(temp)
-        return None
-
-    @callback
-    def _handle_coordinator_update(self) -> None:
-        if self._pending_target is not None:
-            # A unit change invalidates the number outright: 225 held from a
-            # Fahrenheit set must not be presented as 225 C for the rest of
-            # the settle window. The grill's own report wins immediately.
-            if self.temperature_unit != self._pending_unit:
-                self._pending_target = None
-            else:
-                reported = (self.coordinator.data or {}).get("grillSetTemp")
-                if reported is not None and float(reported) == self._pending_target:
-                    self._pending_target = None
-        super()._handle_coordinator_update()
+        return self.coordinator.grill_setpoint()
 
     async def async_set_temperature(self, **kwargs) -> None:
         if (temp := kwargs.get(ATTR_TEMPERATURE)) is None:
             return
-        # Snapped here as well as in pytboss -- deliberately the same
-        # arithmetic -- so what is held and shown is the value the board
-        # will actually report, not the one it will silently correct.
-        wanted = float(temp)
-        if accepted := self._accepted_setpoints:
-            asked = wanted
-            wanted = min(accepted, key=lambda value: abs(value - asked))
-        await self.coordinator.api.set_grill_temperature(int(wanted))
-        self._pending_target = wanted
-        self._pending_unit = self.temperature_unit
-        self.async_write_ha_state()
-        # The MCU reports back within a couple of seconds; an immediate
-        # refresh would only read the cleared status. A second set inside
-        # the window replaces the timer rather than queueing another.
-        self._cancel_pending_settle()
-        self._cancel_settle = async_call_later(
-            self.hass, MCU_SETTLE_SECONDS, self._async_confirm
-        )
-
-    async def _async_confirm(self, _now) -> None:
-        self._cancel_settle = None
-        await self.coordinator.async_request_refresh()
-        # One settle window is all the pending value is for. If the refresh
-        # confirmed it, `_handle_coordinator_update` has already cleared it;
-        # if the grill did not take it, follow the grill rather than assert
-        # a value it will never report.
-        if self._pending_target is not None:
-            self._pending_target = None
-            self.async_write_ha_state()
+        await self.coordinator.async_set_grill_setpoint(float(temp))
 
     async def async_turn_off(self) -> None:
         """Turn off the grill."""

--- a/custom_components/pitboss/const.py
+++ b/custom_components/pitboss/const.py
@@ -36,6 +36,12 @@ DEFAULT_PROBE_MIN_TEMP = 50
 DEFAULT_PROBE_MAX_TEMP = 250
 DEFAULT_PROBE_FAHRENHEIT_STEP = 1
 DEFAULT_PROBE_CELSIUS_STEP = 1
+# How far a grill setpoint control moves per press. Coarser than the list the
+# board actually honours in places, which is why every set is snapped through
+# `PitBossDataUpdateCoordinator.snap_setpoint` rather than sent as dialled --
+# these only keep a slider's own increments close to the real ones.
+GRILL_FAHRENHEIT_STEP = 5
+GRILL_CELSIUS_STEP = 1
 
 
 def probe_label(has_mpc: bool, probe_number: int) -> str:

--- a/custom_components/pitboss/coordinator.py
+++ b/custom_components/pitboss/coordinator.py
@@ -5,10 +5,11 @@ from time import monotonic
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfTemperature
-from homeassistant.core import HomeAssistant
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util.unit_conversion import TemperatureConverter
 from pytboss.api import PitBoss
@@ -26,6 +27,7 @@ from .const import (
     DOMAIN,
     FAILURES_BEFORE_BACKOFF,
     LOGGER,
+    MCU_SETTLE_SECONDS,
     STANDBY_SCAN_INTERVAL,
     SYS_INFO_INTERVAL,
 )
@@ -84,6 +86,16 @@ class PitBossDataUpdateCoordinator(DataUpdateCoordinator[StateDict]):
         self.probe_targets: dict[int, int] = {}
         self.restored_targets: dict[int, int] = {}
         self._targets_seeded = False
+        # The grill setpoint we asked for, held until the grill confirms it.
+        # Kept here rather than on the climate entity because the setpoint has
+        # more than one reader -- the climate entity and the grill setpoint
+        # number are two controls over one setting, and a value held by
+        # whichever one was used would leave the other showing the old
+        # setpoint for the length of the settle window. `probe_targets` lives
+        # here for the same reason.
+        self._pending_setpoint: float | None = None
+        self._pending_setpoint_unit: str | None = None
+        self._cancel_setpoint_settle: CALLBACK_TYPE | None = None
         # Consecutive failed cycles, for the backoff decision below.
         self._failed_polls = 0
 
@@ -124,6 +136,106 @@ class PitBossDataUpdateCoordinator(DataUpdateCoordinator[StateDict]):
         if (data := self.data) and not data.get("isFahrenheit", True):
             return UnitOfTemperature.CELSIUS
         return UnitOfTemperature.FAHRENHEIT
+
+    def grill_setpoint(self) -> float | None:
+        """The grill's setpoint, or the one just asked for.
+
+        Shows what was asked until the grill confirms it: the board wipes its
+        cached status the moment it forwards a command to the MCU, so the next
+        poll still carries the old setpoint and a control reading it straight
+        back would appear to snap to the previous setting.
+        """
+        if self._pending_setpoint is not None:
+            return self._pending_setpoint
+        if (data := self.data) and (temp := data.get("grillSetTemp")) is not None:
+            return float(temp)
+        return None
+
+    def snap_setpoint(self, temp: float) -> float:
+        """The nearest setpoint the control board will actually honour.
+
+        Snapped here as well as in pytboss -- deliberately the same arithmetic
+        -- so what is held and shown is the value the board will report, not
+        the one it will silently correct.
+        """
+        if accepted := self.accepted_setpoints(self.grill_unit):
+            return min(accepted, key=lambda value: abs(value - temp))
+        return temp
+
+    async def async_set_grill_setpoint(self, temp: float) -> None:
+        """Send a grill setpoint, and hold it until the grill confirms it."""
+        wanted = self.snap_setpoint(temp)
+        await self.api.set_grill_temperature(int(wanted))
+        self._pending_setpoint = wanted
+        self._pending_setpoint_unit = self.grill_unit
+        self.async_update_listeners()
+        # The MCU reports back within a couple of seconds; an immediate
+        # refresh would only read the cleared status. A second set inside the
+        # window replaces the timer rather than queueing another.
+        self._cancel_pending_setpoint_settle()
+        self._cancel_setpoint_settle = async_call_later(
+            self.hass, MCU_SETTLE_SECONDS, self._async_confirm_setpoint
+        )
+
+    @callback
+    def _cancel_pending_setpoint_settle(self) -> None:
+        if self._cancel_setpoint_settle is not None:
+            self._cancel_setpoint_settle()
+            self._cancel_setpoint_settle = None
+
+    async def _async_confirm_setpoint(self, _now) -> None:
+        self._cancel_setpoint_settle = None
+        await self.async_request_refresh()
+        # One settle window is all the pending value is for. If the refresh
+        # confirmed it, `_expire_pending_setpoint` has already cleared it; if
+        # the grill did not take it, follow the grill rather than assert a
+        # value it will never report.
+        if self._pending_setpoint is not None:
+            self._pending_setpoint = None
+            self.async_update_listeners()
+
+    @callback
+    def _expire_pending_setpoint(self) -> None:
+        """Stop holding the asked-for setpoint once it stops meaning anything.
+
+        Either the grill has reported it -- from which point its own answer is
+        the source again, so a later change made at the panel is not masked by
+        a value we are still asserting -- or the grill's unit has flipped,
+        which invalidates the held number outright: 225 held from a Fahrenheit
+        set must not be presented as 225 C for the rest of the window.
+        """
+        if self._pending_setpoint is None:
+            return
+        if self.grill_unit != self._pending_setpoint_unit:
+            self._pending_setpoint = None
+            return
+        reported = (self.data or {}).get("grillSetTemp")
+        if reported is not None and float(reported) == self._pending_setpoint:
+            self._pending_setpoint = None
+
+    @callback
+    def async_update_listeners(self) -> None:
+        """Expire a held setpoint before any entity reads it.
+
+        Overridden rather than hooked into one update path because the state
+        that decision depends on arrives by three of them -- the poll, the
+        push callback and `async_set_updated_data` -- and all three end here.
+        """
+        self._expire_pending_setpoint()
+        super().async_update_listeners()
+
+    async def async_shutdown(self) -> None:
+        """Drop the settle timer along with the refresh one.
+
+        Not for the refresh it would ask for -- the base class sets
+        `_shutdown_requested`, and `_async_refresh` bails out on that, so a
+        late callback does nothing. It is the timer itself: an
+        `async_call_later` left scheduled outlives the entry by up to one
+        settle window, which is what Home Assistant's own tests fail on as a
+        lingering timer.
+        """
+        self._cancel_pending_setpoint_settle()
+        await super().async_shutdown()
 
     def probe_target(self, probe_number: int) -> int | None:
         """This probe's target, in the grill's own unit.

--- a/custom_components/pitboss/number.py
+++ b/custom_components/pitboss/number.py
@@ -3,7 +3,11 @@
 from dataclasses import dataclass
 from typing import Literal
 
-from homeassistant.components.number import NumberEntityDescription, RestoreNumber
+from homeassistant.components.number import (
+    NumberEntity,
+    NumberEntityDescription,
+    RestoreNumber,
+)
 from homeassistant.components.number.const import NumberDeviceClass
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfTemperature
@@ -18,6 +22,8 @@ from .const import (
     DEFAULT_PROBE_MAX_TEMP,
     DEFAULT_PROBE_MIN_TEMP,
     DOMAIN,
+    GRILL_CELSIUS_STEP,
+    GRILL_FAHRENHEIT_STEP,
     MCU_SETTLE_SECONDS,
     probe_label,
 )
@@ -50,13 +56,81 @@ async def async_setup_entry(
     # No model in the catalogue declares 0, but an unknown grill having no
     # probes should mean no probe targets rather than one.
     probe_count = coordinator.api.spec.meat_probes or 0
-    entities = [
+    entities: list[NumberEntity] = [
         TargetProbeTemperature(coordinator, entry.unique_id, description)
         for description in PROBE_DESCRIPTIONS
         if description.probe_number <= probe_count
     ]
-    if entities:
-        async_add_entities(entities)
+    entities.append(ChamberSetpoint(coordinator, entry.unique_id))
+    async_add_entities(entities)
+
+
+class ChamberSetpoint(BaseEntity, NumberEntity):
+    """The grill's setpoint, alongside the climate entity's slider.
+
+    Disabled by default, and the writable half of what
+    https://github.com/dknowles2/ha-pitboss/issues/113 asks for: a `number`
+    resolves a per-entity unit from the entity registry, a `climate` entity
+    does not, so this is the only way to dial the grill in Fahrenheit from a
+    Home Assistant running in Celsius. See `ChamberTemperature` for the
+    readout and for why the climate entity stays.
+
+    Both controls write through the coordinator, so setting one moves the
+    other immediately rather than at the end of the settle window.
+    """
+
+    _attr_device_class = NumberDeviceClass.TEMPERATURE
+    _attr_icon = "mdi:thermometer"
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(
+        self,
+        coordinator: PitBossDataUpdateCoordinator,
+        entry_unique_id: str,
+    ) -> None:
+        super().__init__(coordinator, entry_unique_id)
+        self._attr_unique_id = f"chamber_setpoint_{entry_unique_id}"
+        self._attr_name = "Chamber setpoint"
+
+    @property
+    def native_unit_of_measurement(self) -> str:
+        return self.coordinator.grill_unit
+
+    @property
+    def native_step(self) -> float:
+        """The step, in whatever unit the value is being *displayed* in.
+
+        `NumberEntity` converts the minimum and the maximum into the unit the
+        user picked but passes `native_step` through untouched, so a step
+        chosen for the grill's unit would be applied to the other one -- five
+        Celsius degrees where five Fahrenheit was meant. Keyed off
+        `unit_of_measurement`, which is the registry override when there is
+        one and the unit system otherwise.
+        """
+        if self.unit_of_measurement == UnitOfTemperature.FAHRENHEIT:
+            return float(GRILL_FAHRENHEIT_STEP)
+        return float(GRILL_CELSIUS_STEP)
+
+    @property
+    def _accepted_setpoints(self) -> list[float]:
+        return self.coordinator.accepted_setpoints(self.coordinator.grill_unit)
+
+    @property
+    def native_min_value(self) -> float:
+        # The setpoint list, with nothing behind it -- the same bounds the
+        # climate entity publishes, from the same source.
+        return min(self._accepted_setpoints)
+
+    @property
+    def native_max_value(self) -> float:
+        return max(self._accepted_setpoints)
+
+    @property
+    def native_value(self) -> float | None:
+        return self.coordinator.grill_setpoint()
+
+    async def async_set_native_value(self, value: float) -> None:
+        await self.coordinator.async_set_grill_setpoint(value)
 
 
 class TargetProbeTemperature(BaseEntity, RestoreNumber):

--- a/custom_components/pitboss/sensor.py
+++ b/custom_components/pitboss/sensor.py
@@ -99,6 +99,7 @@ async def async_setup_entry(
     for description in SYS_INFO_DESCRIPTIONS:
         entities.append(SysInfoSensor(coordinator, entry.unique_id, description))
     entities.append(FirmwareSensor(coordinator, entry.unique_id))
+    entities.append(ChamberTemperature(coordinator, entry.unique_id))
     if coordinator.api.spec.json.get("has_recipe_functionality", False):
         for entity_description in RECIPE_ENTITY_DESCRIPTIONS:
             entities.append(
@@ -161,6 +162,54 @@ class ProbeSensor(BaseSensorEntity):
         if (data := self.coordinator.data) and not data.get("isFahrenheit", True):
             return UnitOfTemperature.CELSIUS
         return UnitOfTemperature.FAHRENHEIT
+
+
+class ChamberTemperature(BaseEntity, SensorEntity):
+    """The grill's own temperature, alongside the climate entity.
+
+    Disabled by default: it is the same reading the climate entity already
+    publishes, and exists only because `climate` is the one platform whose
+    unit cannot be overridden per entity. `sensor` and `number` resolve a
+    unit from the entity registry -- `climate/__init__.py` has no such
+    lookup at all -- so a grill running in Celsius cannot be shown in
+    Fahrenheit on a metric Home Assistant, which is what
+    https://github.com/dknowles2/ha-pitboss/issues/113 asks for.
+
+    Enabling this and the grill setpoint number gives a readout and a
+    control that both take a unit under the entity's own settings. The
+    climate entity is deliberately left in place: it is what voice control
+    reaches (`climate/intent.py` scopes itself to that domain) and what
+    carries `hvac_action`, neither of which a sensor can replace.
+    """
+
+    _attr_device_class = SensorDeviceClass.TEMPERATURE
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_icon = "mdi:thermometer"
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(
+        self,
+        coordinator: PitBossDataUpdateCoordinator,
+        entry_unique_id: str,
+    ) -> None:
+        super().__init__(coordinator, entry_unique_id)
+        self._attr_unique_id = f"chamber_temp_{entry_unique_id}"
+        self._attr_name = "Chamber temperature"
+
+    @property
+    def native_unit_of_measurement(self) -> str:
+        return self.coordinator.grill_unit
+
+    @property
+    def native_value(self) -> float | None:
+        # Checked for None rather than presence, as the climate entity does:
+        # the boards put null on the wire for the no-reading sentinel, so a
+        # chamber sensor that is out reads as unknown rather than raising.
+        if (data := self.coordinator.data) and (
+            temp := data.get("grillTemp")
+        ) is not None:
+            return float(temp)
+        return None
 
 
 class RecipeSensor(BaseSensorEntity):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ import pytest
 from homeassistant.const import CONF_DEVICE_ID, CONF_MODEL, CONF_PASSWORD, CONF_PROTOCOL
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_platform as ep
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity import Entity
 from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM, UnitSystem
 from pytboss.grills import Grill, get_grill
@@ -30,6 +31,26 @@ def get_entity[EntityT: Entity](
             assert isinstance(entity, entity_type)
             return entity
     raise AssertionError(f"{platform_domain} platform not found")
+
+
+async def enable_entity(
+    hass: HomeAssistant,
+    entry: MockConfigEntry,
+    platform_domain: str,
+    unique_id: str,
+) -> str:
+    """Turn on an entity that ships disabled, and return its entity id.
+
+    Reloads the entry, because a registry row going from disabled to enabled
+    is only acted on when the platform next sets up.
+    """
+    registry = er.async_get(hass)
+    entity_id = registry.async_get_entity_id(platform_domain, DOMAIN, unique_id)
+    assert entity_id is not None
+    registry.async_update_entity(entity_id, disabled_by=None)
+    await hass.config_entries.async_reload(entry.entry_id)
+    await hass.async_block_till_done()
+    return entity_id
 
 
 @pytest.fixture(autouse=True, scope="session")

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -3,11 +3,13 @@ from datetime import timedelta
 from unittest.mock import Mock
 
 import pytest
-from conftest import get_entity
+from conftest import enable_entity, get_entity
 from freezegun.api import FrozenDateTimeFactory
 from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant, State
+from homeassistant.helpers import entity_registry as er
 from homeassistant.util import dt as dt_util
+from homeassistant.util.unit_system import METRIC_SYSTEM, US_CUSTOMARY_SYSTEM
 from pytboss.exceptions import UnsupportedOperation
 from pytest_homeassistant_custom_component.common import (
     MockConfigEntry,
@@ -612,3 +614,173 @@ async def test_a_second_set_replaces_the_window_rather_than_queueing(
     state = hass.states.get("number.mygrill_mpc_target")
     assert state is not None
     assert state.state == "165"
+
+
+@pytest.mark.parametrize("model", ["PBV4PS2"])
+async def test_chamber_setpoint_ships_disabled(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+) -> None:
+    """A second control over a setting the climate entity already exposes."""
+    await mock_add_config_entry()
+    assert hass.states.get("number.mygrill_chamber_setpoint") is None
+    registry = er.async_get(hass)
+    entity_id = registry.async_get_entity_id(
+        "number", DOMAIN, "chamber_setpoint_mygrillid"
+    )
+    assert entity_id is not None
+    entry = registry.async_get(entity_id)
+    assert entry is not None
+    assert entry.disabled_by is not None
+
+
+@pytest.mark.parametrize("model", ["PBV4PS2"])
+async def test_chamber_setpoint_snaps_to_what_the_board_honours(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+    mock_pitboss: Mock,
+) -> None:
+    entry = await mock_add_config_entry()
+    entity_id = await enable_entity(hass, entry, "number", "chamber_setpoint_mygrillid")
+    coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator.async_set_updated_data({"isFahrenheit": True, "grillSetTemp": 250})
+    await hass.async_block_till_done()
+    mock_pitboss.set_grill_temperature.reset_mock()
+
+    await hass.services.async_call(
+        "number",
+        "set_value",
+        {"entity_id": entity_id, "value": 275},
+        blocking=True,
+    )
+
+    # PBV4PS2's board takes setpoints in tens; 275 is not on its list.
+    mock_pitboss.set_grill_temperature.assert_awaited_once_with(270)
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert float(state.state) == 270.0
+
+
+@pytest.mark.parametrize("model", ["PBV4PS2"])
+async def test_chamber_setpoint_bounds_come_from_the_boards_setpoints(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+) -> None:
+    """The same bounds the climate entity publishes, from the same source."""
+    entry = await mock_add_config_entry()
+    entity_id = await enable_entity(hass, entry, "number", "chamber_setpoint_mygrillid")
+    coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator.async_set_updated_data({"isFahrenheit": True})
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.attributes["min"] == 130
+    assert state.attributes["max"] == 420
+    climate = hass.states.get("climate.mygrill_grill_temperature")
+    assert climate is not None
+    assert state.attributes["min"] == climate.attributes["min_temp"]
+    assert state.attributes["max"] == climate.attributes["max_temp"]
+
+
+@pytest.mark.parametrize("model", ["PBV4PS2"])
+@pytest.mark.parametrize(
+    "units,want_step", [(US_CUSTOMARY_SYSTEM, 5.0), (METRIC_SYSTEM, 1.0)]
+)
+async def test_chamber_setpoint_steps_in_the_unit_it_is_shown_in(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+    want_step: float,
+) -> None:
+    """`NumberEntity` converts the bounds but passes the step through as-is.
+
+    So a step picked for the grill's own unit would be applied to whichever
+    unit the value is displayed in -- five Celsius degrees where five
+    Fahrenheit was meant. Same Fahrenheit grill both times; only the unit it
+    is being shown in differs.
+    """
+    entry = await mock_add_config_entry()
+    entity_id = await enable_entity(hass, entry, "number", "chamber_setpoint_mygrillid")
+    coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator.async_set_updated_data({"isFahrenheit": True})
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.attributes["step"] == want_step
+
+
+@pytest.mark.parametrize("model", ["PBV4PS2"])
+async def test_the_two_setpoint_controls_never_disagree(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+    mock_pitboss: Mock,
+) -> None:
+    """The reason the held setpoint lives on the coordinator.
+
+    Held per entity, whichever control was not used would go on showing the
+    previous setpoint for the length of the settle window -- the grill has
+    not reported the new one yet, and that is all a second entity could read.
+    """
+    entry = await mock_add_config_entry()
+    entity_id = await enable_entity(hass, entry, "number", "chamber_setpoint_mygrillid")
+    coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator.async_set_updated_data(
+        {"moduleIsOn": True, "isFahrenheit": True, "grillSetTemp": 250}
+    )
+    await hass.async_block_till_done()
+
+    # Set on the climate entity; the number follows at once.
+    await hass.services.async_call(
+        "climate",
+        "set_temperature",
+        {"entity_id": "climate.mygrill_grill_temperature", "temperature": 300},
+        blocking=True,
+    )
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert float(state.state) == 300.0
+
+    # And the other way round.
+    await hass.services.async_call(
+        "number",
+        "set_value",
+        {"entity_id": entity_id, "value": 200},
+        blocking=True,
+    )
+    climate = hass.states.get("climate.mygrill_grill_temperature")
+    assert climate is not None
+    assert climate.attributes["temperature"] == 200.0
+
+
+@pytest.mark.parametrize("model", ["PBV4PS2"])
+async def test_the_settle_timer_does_not_outlive_the_entry(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+    mock_pitboss: Mock,
+) -> None:
+    """Otherwise an `async_call_later` stays scheduled past the unload.
+
+    Asserted on the handle rather than on a refresh that never comes: the
+    base coordinator refuses to refresh once shut down, so the callback
+    firing is harmless in itself and only the live timer is the problem.
+    """
+    entry = await mock_add_config_entry()
+    coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator.async_set_updated_data(
+        {"moduleIsOn": True, "isFahrenheit": True, "grillSetTemp": 250}
+    )
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        "climate",
+        "set_temperature",
+        {"entity_id": "climate.mygrill_grill_temperature", "temperature": 300},
+        blocking=True,
+    )
+    assert coordinator._cancel_setpoint_settle is not None
+
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert coordinator._cancel_setpoint_settle is None

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -379,7 +379,9 @@ async def test_chamber_temperature_null_reading_is_unknown(
     entry = await mock_add_config_entry()
     entity_id = await enable_entity(hass, entry, "sensor", "chamber_temp_mygrillid")
     coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
-    coordinator.async_set_updated_data({"isFahrenheit": True, "grillTemp": None})
+    coordinator.async_set_updated_data(
+        cast(StateDict, {"isFahrenheit": True, "grillTemp": None})
+    )
     await hass.async_block_till_done()
 
     state = hass.states.get(entity_id)

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -4,12 +4,13 @@ from typing import cast
 from unittest.mock import Mock
 
 import pytest
-from conftest import get_entity
-from homeassistant.const import STATE_UNAVAILABLE
+from conftest import enable_entity, get_entity
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
 from homeassistant.util import dt as dt_util
+from homeassistant.util.unit_system import METRIC_SYSTEM
 from pytboss.grills import StateDict
 from pytest_homeassistant_custom_component.common import (
     MockConfigEntry,
@@ -327,3 +328,96 @@ async def test_a_late_firmware_read_reaches_the_device_page(
     device = registry.async_get_device(identifiers={(DOMAIN, "mygrill")})
     assert device is not None
     assert device.sw_version == "0.5.7"
+
+
+@pytest.mark.parametrize("model", ["PBV4PS2"])
+async def test_chamber_temperature_ships_disabled(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+) -> None:
+    """It duplicates a reading the climate entity already publishes.
+
+    Only worth having for the unit override it accepts and the climate
+    entity does not, so it stays out of the way until someone asks for it.
+    """
+    await mock_add_config_entry()
+    assert hass.states.get("sensor.mygrill_chamber_temperature") is None
+    registry = er.async_get(hass)
+    entity_id = registry.async_get_entity_id("sensor", DOMAIN, "chamber_temp_mygrillid")
+    assert entity_id is not None
+    entry = registry.async_get(entity_id)
+    assert entry is not None
+    assert entry.disabled_by is not None
+
+
+@pytest.mark.parametrize("model", ["PBV4PS2"])
+async def test_chamber_temperature_mirrors_the_climate_reading(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+) -> None:
+    entry = await mock_add_config_entry()
+    entity_id = await enable_entity(hass, entry, "sensor", "chamber_temp_mygrillid")
+    coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator.async_set_updated_data({"isFahrenheit": True, "grillTemp": 275})
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert float(state.state) == 275.0
+    assert state.attributes["unit_of_measurement"] == UnitOfTemperature.FAHRENHEIT
+    climate = hass.states.get("climate.mygrill_grill_temperature")
+    assert climate is not None
+    assert climate.attributes["current_temperature"] == 275.0
+
+
+@pytest.mark.parametrize("model", ["PBV4PS2"])
+async def test_chamber_temperature_null_reading_is_unknown(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+) -> None:
+    """The boards put null on the wire for the no-reading sentinel."""
+    entry = await mock_add_config_entry()
+    entity_id = await enable_entity(hass, entry, "sensor", "chamber_temp_mygrillid")
+    coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator.async_set_updated_data({"isFahrenheit": True, "grillTemp": None})
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == STATE_UNKNOWN
+
+
+@pytest.mark.parametrize("model", ["PBV4PS2"])
+@pytest.mark.parametrize("units", [METRIC_SYSTEM])
+async def test_chamber_temperature_takes_a_unit_override(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+) -> None:
+    """The entire reason this entity exists.
+
+    A Celsius grill on a metric Home Assistant, shown in Fahrenheit. The
+    climate entity is fed the same registry option and ignores it -- there is
+    no lookup for it in `climate/__init__.py` -- which is what this asserts by
+    reading both at once.
+    """
+    entry = await mock_add_config_entry()
+    entity_id = await enable_entity(hass, entry, "sensor", "chamber_temp_mygrillid")
+    registry = er.async_get(hass)
+    registry.async_update_entity_options(
+        entity_id,
+        "sensor",
+        {"unit_of_measurement": UnitOfTemperature.FAHRENHEIT},
+    )
+    await hass.async_block_till_done()
+    coordinator: PitBossDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator.async_set_updated_data({"isFahrenheit": False, "grillTemp": 121})
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.attributes["unit_of_measurement"] == UnitOfTemperature.FAHRENHEIT
+    assert float(state.state) == pytest.approx(249.8)
+
+    climate = hass.states.get("climate.mygrill_grill_temperature")
+    assert climate is not None
+    assert climate.attributes["current_temperature"] == 121.0


### PR DESCRIPTION
Closes the practical half of #113.

## The problem

Home Assistant resolves a per-entity unit of measurement from the entity registry for exactly two platforms. I grepped every one of them in 2026.8.0:

- `sensor` — yes
- `number` — yes
- everything else, `climate` and `water_heater` included — no lookup at all

So a grill running in Celsius cannot be shown in Fahrenheit on a Home Assistant set to metric. That is the ask in #113, and it is genuinely core-side.

## What this does

Adds a `Chamber temperature` sensor and a `Chamber setpoint` number that mirror the climate entity, **both disabled by default**. Anyone who wants the grill in a unit other than their unit system enables the two and sets the unit under each entity's own settings. Everyone else never sees them.

The climate entity stays. It is what voice control reaches — `climate/intent.py` scopes itself to that domain — and what carries `hvac_action`. Replacing it behind an option would also mean removing registry rows on a toggle, in both directions, and silently breaking every automation and dashboard card that names it.

## The setpoint now has two controls

So the value held while the MCU settles moved from the climate entity to the coordinator, next to `probe_targets`, which lives there for the same reason. Held per entity, whichever control was *not* used would go on showing the previous setpoint for the length of the settle window — the grill has not reported the new one yet, and that is all a second entity could read.

`climate.py` gets ~50 lines shorter and keeps all 24 of its existing tests unchanged.

## Two things found on the way

**`NumberEntity` converts the bounds but not the step.** `_calculate_step` returns `native_step` verbatim while min and max go through the converter, so a step chosen for the grill's unit would be applied to whichever unit the value is displayed in — five Celsius degrees where five Fahrenheit was meant. `native_step` is keyed off `unit_of_measurement` (the override when there is one, the unit system otherwise) rather than `native_unit_of_measurement`.

**The settle timer outlived the entry.** Now unscheduled on shutdown. Not for the refresh it would ask for — the base coordinator sets `_shutdown_requested` and refuses — but because the `async_call_later` itself stayed scheduled for up to a window past unload.

## Verification

210 tests pass. 11 are new, and I checked they are load-bearing by mutating the code each one covers:

| Mutation | Result |
| --- | --- |
| `native_step` keyed off the grill's unit instead of the displayed one | 1 failed |
| coordinator stops holding the asked-for setpoint | 5 failed |
| `async_shutdown` stops cancelling the settle timer | 1 failed |
| chamber sensor no longer ships disabled | 1 failed |

The third one initially caught nothing — my first version of that test asserted no refresh happened, which the base class already guarantees whether or not the cancel is there. Re-aimed at the timer handle, which is what the cancel actually controls, and fixed the comments that claimed otherwise.

The load-bearing test is `test_chamber_temperature_takes_a_unit_override`: a Celsius grill on a metric Home Assistant, reading 249.8 °F on the sensor and 121.0 °C on the climate entity at the same moment, from the same registry option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)