### PR TITLE
Convert the held probe targets when the grill's unit flips

### DIFF
--- a/custom_components/pitboss/coordinator.py
+++ b/custom_components/pitboss/coordinator.py
@@ -138,7 +138,12 @@ class PitBossDataUpdateCoordinator(DataUpdateCoordinator[StateDict]):
         Celsius meant presenting one unit while commands were snapped in the
         other.
         """
-        if (data := self.data) and not data.get("isFahrenheit", True):
+        return self._unit_of(self.data or StateDict())
+
+    @staticmethod
+    def _unit_of(state: StateDict) -> str:
+        """The unit a state frame is expressed in."""
+        if not state.get("isFahrenheit", True):
             return UnitOfTemperature.CELSIUS
         return UnitOfTemperature.FAHRENHEIT
 
@@ -348,6 +353,14 @@ class PitBossDataUpdateCoordinator(DataUpdateCoordinator[StateDict]):
         try:
             # Copied: we add to this below, and it is not ours to mutate.
             self.probe_targets = dict(await self.api.get_probe_targets())
+            # Recorded at the point of the read rather than left for
+            # `_follow_probe_targets_unit` to infer: these values came back
+            # in the unit of the frame that carried them, and `self.data` is
+            # not updated until this poll returns -- so the inference would
+            # see a flip that has already been accounted for and convert
+            # them a second time. `state` is the merged frame, so a partial
+            # one that omits the flag still carries the previous value.
+            self._targets_unit = self._unit_of(state)
         except Exception as ex:  # noqa: BLE001
             self.logger.debug("Could not fetch the probe targets: %s", ex)
             return

--- a/custom_components/pitboss/coordinator.py
+++ b/custom_components/pitboss/coordinator.py
@@ -86,6 +86,11 @@ class PitBossDataUpdateCoordinator(DataUpdateCoordinator[StateDict]):
         self.probe_targets: dict[int, int] = {}
         self.restored_targets: dict[int, int] = {}
         self._targets_seeded = False
+        # The unit `probe_targets` was last known to be in, so a unit change
+        # can convert the held values instead of serving them mislabeled.
+        # `None` until the first update: the unit read before any data is
+        # the Fahrenheit default, not something the grill said.
+        self._targets_unit: str | None = None
         # The grill setpoint we asked for, held until the grill confirms it.
         # Kept here rather than on the climate entity because the setpoint has
         # more than one reader -- the climate entity and the grill setpoint
@@ -214,14 +219,47 @@ class PitBossDataUpdateCoordinator(DataUpdateCoordinator[StateDict]):
             self._pending_setpoint = None
 
     @callback
+    def _follow_probe_targets_unit(self) -> None:
+        """Convert the held probe targets when the grill's unit flips.
+
+        `probe_targets` holds values in the grill's unit, and the poll is the
+        only path that refreshes it -- a unit change arriving by push left
+        the old-unit numbers in place for up to a poll interval. In that
+        window a target number showed the old value labeled with the new
+        unit, and target-reached compared across units: a probe reading
+        140 F sat above a target of 74 held from Celsius, so the sensor
+        fired for a probe that was 14 degrees C short.
+
+        Converted rather than dropped so the target stays on the dashboard;
+        the next poll re-reads what the grill is actually holding. Only the
+        probes whose target is not board-reported are exposed to this --
+        `probe_target` prefers the state's own `pNTarget`, which arrives
+        already flipped -- but those are most probes on most boards.
+        `restored_targets` needs nothing: it is kept in Fahrenheit for
+        exactly this reason.
+        """
+        unit = self.grill_unit
+        if self._targets_unit is None or not self.probe_targets:
+            self._targets_unit = unit
+            return
+        prev, self._targets_unit = self._targets_unit, unit
+        if unit == prev:
+            return
+        self.probe_targets = {
+            probe_number: round(TemperatureConverter.convert(float(target), prev, unit))
+            for probe_number, target in self.probe_targets.items()
+        }
+
+    @callback
     def async_update_listeners(self) -> None:
-        """Expire a held setpoint before any entity reads it.
+        """Reconcile what we hold with what arrived, before any entity reads.
 
         Overridden rather than hooked into one update path because the state
-        that decision depends on arrives by three of them -- the poll, the
+        these decisions depend on arrives by three of them -- the poll, the
         push callback and `async_set_updated_data` -- and all three end here.
         """
         self._expire_pending_setpoint()
+        self._follow_probe_targets_unit()
         super().async_update_listeners()
 
     async def async_shutdown(self) -> None:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -323,3 +323,27 @@ async def test_a_restored_target_is_seeded_in_the_grills_current_unit(
     mock_pitboss.get_state.return_value = StateDict(moduleIsOn=True, isFahrenheit=True)
     await coordinator._async_update_data()
     mock_pitboss.set_probe_target.assert_awaited_once_with(2, 165)
+
+
+async def test_held_probe_targets_follow_a_unit_flip(
+    coordinator: PitBossDataUpdateCoordinator, mock_pitboss: Mock
+) -> None:
+    """A unit change arriving by push converts the held targets with it.
+
+    `probe_targets` holds grill-unit values and only the poll refreshes it,
+    so a flip pushed between polls left the old-unit numbers in place for up
+    to a poll interval: a target number showed 74 labeled Fahrenheit, and
+    target-reached compared a 140 F probe against a 74 held from Celsius --
+    firing for a probe that was 14 degrees C short. Only probes whose target
+    is not board-reported are exposed, which is why this reads probe 2 with
+    no `p2Target` in the state.
+    """
+    coordinator.async_set_updated_data(StateDict(isFahrenheit=False, moduleIsOn=True))
+    coordinator.probe_targets[2] = 74
+
+    coordinator.async_set_updated_data(StateDict(isFahrenheit=True, moduleIsOn=True))
+    assert coordinator.probe_target(2) == 165
+
+    # And back, in case the flip was a mistake being corrected.
+    coordinator.async_set_updated_data(StateDict(isFahrenheit=False, moduleIsOn=True))
+    assert coordinator.probe_target(2) == 74

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -347,3 +347,22 @@ async def test_held_probe_targets_follow_a_unit_flip(
     # And back, in case the flip was a mistake being corrected.
     coordinator.async_set_updated_data(StateDict(isFahrenheit=False, moduleIsOn=True))
     assert coordinator.probe_target(2) == 74
+
+
+async def test_a_unit_flip_arriving_by_poll(
+    coordinator: PitBossDataUpdateCoordinator, mock_pitboss: Mock
+) -> None:
+    """The poll re-reads the targets from the grill, already in the new unit."""
+    coordinator._api_started = True
+    mock_pitboss.is_connected.return_value = True
+
+    mock_pitboss.get_state.return_value = StateDict(moduleIsOn=True, isFahrenheit=True)
+    mock_pitboss.get_probe_targets.return_value = {3: 165}
+    await coordinator.async_refresh()
+    assert coordinator.probe_target(3) == 165
+
+    mock_pitboss.get_state.return_value = StateDict(moduleIsOn=True, isFahrenheit=False)
+    mock_pitboss.get_probe_targets.return_value = {3: 74}
+    await coordinator.async_refresh()
+
+    assert coordinator.probe_target(3) == 74


### PR DESCRIPTION
Found sweeping the released stack (pytboss `2026.8.5` + `2026.8.1`) with synthesized frames through the boards' own parsing routines.

## The window

`probe_targets` holds values in the grill's unit, and the poll is the only path that refreshes it — `_on_state_update` applies the poll interval and publishes the state, but never touches the targets. A unit change arriving by push therefore leaves the old-unit numbers in place for up to a poll interval (10 s lit, 60 s in standby). In that window:

- a probe target number shows the old value labeled with the new unit — **74 °F** where 74 °C was set;
- target-reached compares across units: a probe reading **140 °F** sits above a target of **74** held from Celsius, so the sensor fires for a probe that is 14 °C short of done.

Only probes whose target is not board-reported are exposed — `probe_target()` prefers the state's own `pNTarget`, which arrives already flipped — but that is most probes on most boards: `p2Target` is emitted by 26 of 137 models, `p3`/`p4` by none.

## The fix

Converted rather than dropped, so the target stays on the dashboard; the next poll re-reads what the grill is actually holding. Done in `async_update_listeners`, where the pending setpoint already expires for the same reason — the state these decisions depend on arrives by three paths, and all three end there. `restored_targets` needs nothing: it is kept in Fahrenheit for exactly this reason, per its own comment.

The unit is tracked from `None` rather than seeded from `grill_unit` at construction, since the unit read before any data is the Fahrenheit default, not something the grill said.

The test drives the flip through `async_set_updated_data` (the push path), asserts 74 °C → 165 °F, and flips back — a conversion that drifted (floor instead of round) would fail the round trip.

211 passed, ruff / ruff format / mypy clean. Verified the test fails without the conversion, not just passes with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)