### PR TITLE
Move to Home Assistant 2026.8.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
 aioesphomeapi==45.7.0
 aiousbwatcher==1.1.2
 colorlog==6.12.0
-homeassistant==2026.7.4
+homeassistant==2026.8.0
 mypy==2.3.0
 pip>=26.2
 pyserial-asyncio==0.6
 pyserial==3.5
 pytboss==2026.8.5
-pytest_homeassistant_custom_component==0.13.348
+pytest_homeassistant_custom_component==0.13.354
 ruff==0.16.1
 serialx==1.8.2


### PR DESCRIPTION
Unblocks the dependabot group, which has been stuck since 2026-08-03.

`pytest-homeassistant-custom-component` pins an *exact* Home Assistant, so the two move together or not at all. Every release in the group until now pinned a 2026.8.0 **beta**, which will not resolve against a stable `homeassistant==` pin — so the bump could go in neither direction and #364 sat red for reasons that had nothing to do with the code.

`0.13.354` pins `homeassistant==2026.8.0` stable. Verified on the simple index, which is what `uv` actually resolves against:

```
0.13.350  0.13.351  0.13.352  0.13.353  0.13.354
```

Supersedes #364 — that one was raised against `0.13.351` and is three releases behind.

## While here: a correction to #392

I reported there that I had grepped Home Assistant **2026.8.0** to establish which platforms resolve a per-entity unit from the entity registry. The venv was on 2026.7.4 at the time, so that grep was against 2026.7.4.

Re-run against 2026.8.0 now that it is installed, both findings hold unchanged:

- platforms with a registry unit override: `number`, `sensor` — and no others
- `climate/__init__.py`: no such lookup at all
- `NumberEntity._calculate_step` still returns `native_step` verbatim while min and max go through the converter

So #392's conclusions stand and nothing there needs revisiting. The version I named was wrong, not the result.

## Verification

On 2026.8.0: 210 tests pass, `mypy .` clean over the whole tree, `ruff` and `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)