### PR TITLE
Test the contract with pytboss, not just our reasoning about it

### DIFF
--- a/tests/test_pytboss_contract.py
+++ b/tests/test_pytboss_contract.py
@@ -1,0 +1,147 @@
+"""The contract between this integration and pytboss.
+
+Every other test in this suite runs against a mocked `pytboss.api.PitBoss`,
+so the state dictionaries the entities are driven from are written here by
+hand. That makes the suite fast and precise about *this* repo's reasoning,
+and blind to the boundary: pytboss could rename a key, drop a field, or stop
+emitting one on some board, and nothing here would fail until a user
+reported an entity stuck at unknown.
+
+These tests read the real library instead of a mock. They do not exercise
+the transports -- that needs a grill -- but they hold the two things most
+likely to drift apart between releases of two repos that ship separately.
+"""
+
+from typing import get_type_hints
+
+import pytest
+from pytboss import grills
+from pytboss.grills import StateDict
+
+from custom_components.pitboss.binary_sensor import (
+    ENTITY_DESCRIPTIONS as BINARY_SENSOR_DESCRIPTIONS,
+)
+from custom_components.pitboss.sensor import PROBE_ENTITY_DESCRIPTIONS
+
+# Keys this integration reads out of a state dictionary. Kept as a literal
+# rather than scraped from the source: the point is to notice when the two
+# repos disagree, and a list derived from the same code it is checking would
+# follow a rename rather than catch it.
+STATE_KEYS_READ = frozenset(
+    {
+        "erL",
+        "err1",
+        "err2",
+        "err3",
+        "fanErr",
+        "fanState",
+        "grillSetTemp",
+        "grillTemp",
+        "highTempErr",
+        "hotErr",
+        "hotState",
+        "isFahrenheit",
+        "lightState",
+        "moduleIsOn",
+        "motorErr",
+        "motorState",
+        "noPellets",
+        "p1Temp",
+        "p2Temp",
+        "p3Temp",
+        "p4Temp",
+        "primeState",
+        "recipeStep",
+        "recipeTime",
+    }
+)
+
+# `probe_target` reads `pNTarget` for every probe the grill has, but pytboss
+# only ever puts probes 1 and 2 in the state -- no board's routine emits a
+# third or fourth. The read is deliberate rather than dead: it costs nothing,
+# and a definitions refresh that starts emitting one would be picked up
+# without a change here. Listed so the subset check below stays honest about
+# what it is not covering.
+PROBE_TARGET_KEYS_READ_BUT_NEVER_EMITTED = frozenset({"p3Target", "p4Target"})
+
+
+def test_every_state_key_the_integration_reads_is_declared_by_pytboss() -> None:
+    """A renamed or dropped key should fail here, not in someone's logbook."""
+    declared = set(get_type_hints(StateDict))
+    assert STATE_KEYS_READ <= declared, (
+        "these keys are read by the integration but no longer declared by "
+        f"pytboss's StateDict: {sorted(STATE_KEYS_READ - declared)}"
+    )
+
+
+def test_the_probe_target_keys_we_tolerate_missing_are_still_missing() -> None:
+    """The moment a board reports one, the tolerance above is worth revisiting.
+
+    Not a failure so much as a prompt: probes 3 and 4 would gain a
+    board-reported target, which `probe_target` already prefers over the
+    virtual data store.
+    """
+    declared = set(get_type_hints(StateDict))
+    assert not (PROBE_TARGET_KEYS_READ_BUT_NEVER_EMITTED & declared), (
+        "pytboss now declares a probe target this integration assumed was "
+        "never reported; check `probe_target`'s ordering still makes sense"
+    )
+
+
+def test_every_binary_sensor_key_is_a_field_pytboss_declares() -> None:
+    """A description keyed to something pytboss does not report is dead.
+
+    `emits()` would answer False for it on every board, so the entity would
+    silently never be created anywhere -- which looks identical to the
+    feature working until someone goes looking for the sensor. A typo in a
+    new description fails here instead.
+    """
+    declared = set(get_type_hints(StateDict))
+    keyed = {d.key for d in BINARY_SENSOR_DESCRIPTIONS}
+    assert keyed <= declared, (
+        "binary sensor descriptions keyed to fields pytboss does not "
+        f"declare: {sorted(keyed - declared)}"
+    )
+
+
+def test_every_binary_sensor_description_is_reachable_on_some_board() -> None:
+    """The same rot, caught one step later.
+
+    A field can be declared by `StateDict` and still be emitted by no board
+    -- pytboss drops some per board, and a definitions refresh can retire
+    one outright. Either way the description is dead weight, and nobody
+    finds out from an entity that is simply absent.
+    """
+    boards = {g.control_board.name: g.control_board for g in grills.get_grills()}
+    unreachable = [
+        d.key
+        for d in BINARY_SENSOR_DESCRIPTIONS
+        if not any(b.emits(d.key) for b in boards.values())
+    ]
+    assert not unreachable, (
+        f"no catalogued board reports these, so the entities are never "
+        f"created for anyone: {sorted(unreachable)}"
+    )
+
+
+@pytest.mark.parametrize("grill", grills.get_grills(), ids=lambda g: g.name)
+def test_every_probe_the_grill_declares_can_actually_be_reported(
+    grill: grills.Grill,
+) -> None:
+    """`meat_probes` decides which probe sensors ship enabled.
+
+    It comes from the model, and whether the field can be reported at all
+    comes from the board's parsing routine -- two different sources that
+    have to agree, or a grill ships an enabled sensor that is unknown for
+    the life of the entry.
+    """
+    board = grill.control_board
+    probes = grill.meat_probes or 0
+    for description in PROBE_ENTITY_DESCRIPTIONS:
+        if description.probe_number > probes:
+            continue
+        assert board.emits(description.key), (
+            f"{grill.name} declares {probes} meat probes, so probe "
+            f"{description.probe_number} ships enabled, but board "
+            f"{board.name} never reports {description.key}"
+        )


### PR DESCRIPTION
## The gap

Line coverage is 98%. That number is misleading, and here is why:

```
tests/conftest.py:162:  with patch("pytboss.api.PitBoss", autospec=True) as mock_cls:
```

`pytboss.api.PitBoss` is mocked in **every** test in this suite. Only the grill-spec catalogue (`get_grill`) is real. So every state dictionary the entities are driven from — `{"isFahrenheit": True, "grillTemp": 275}` and its siblings — is written by hand in this repo.

That makes the suite fast and precise about *this* repo's reasoning, and completely blind to the boundary. pytboss could rename a key, drop a field, or stop emitting one on some board, and nothing here would fail. The user finds out instead, from an entity stuck at unknown. That is exactly how #391 was found — from field observations, not from CI.

98% of the integration's reasoning about a fiction is still 98% of a fiction.

## What this adds

Four claims read out of the real library rather than a mock:

| Claim | Catches |
| --- | --- |
| every state key the integration reads is still declared by `StateDict` | a rename or removal in pytboss |
| the probe target keys we tolerate being absent are still absent | a board starting to report `p3Target`/`p4Target`, which would change `probe_target`'s ordering |
| no binary sensor description is keyed to a field pytboss does not declare, **or to one no catalogued board reports** | a typo, or a description that has quietly gone dead |
| every probe a grill declares in `meat_probes` can be reported by its board | the #391 bug class, generalised |

The last is the one with teeth today. `meat_probes` comes from the model and `emits()` comes from the board's parsing routine — two independent sources that have to agree, or a grill ships an enabled sensor that is unknown for the life of the entry. Removing its guard fails 17 models.

The third is worth a word: a description keyed to a field no board reports produces an entity that is never created *for anyone*, which is indistinguishable from the feature working until somebody goes looking for the sensor.

## Verification

353 pass, `mypy .` clean, `ruff`/`ruff format` clean.

Each claim was broken to confirm the test bites, rather than only confirmed to pass:

| Mutation | Result |
| --- | --- |
| a key the integration reads is renamed in the read-set | 1 failed |
| a binary sensor description keyed to a non-field | 1 failed |
| a description no board reports | 1 failed |
| a grill declaring more probes than its board emits | **17 failed** |

I also wrote a fifth test and deleted it before pushing: it branched on `emits()` and then asserted `emits()`, so it could not fail. Mentioned because it is the exact failure mode these tests exist to prevent, and it is easy to write by accident.

## What this does not do

It does not exercise the transports, and it does not parse real frames. pytboss has the machinery for the latter — a frame builder that runs each board's real vendor JavaScript — but it lives in pytboss's own tests and is not importable. Promoting it to a public `pytboss.testing` helper would let this suite drive the integration from genuinely parsed state rather than hand-written dictionaries. That is a pytboss API decision, so it is not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)