### PR TITLE
Make four tests fail when the thing they name is broken

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ from collections.abc import Awaitable, Callable, Generator
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_DEVICE_ID, CONF_MODEL, CONF_PASSWORD, CONF_PROTOCOL
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_platform as ep
@@ -138,7 +139,13 @@ async def mock_add_config_entry(
         mock_config_entry.add_to_hass(hass)
         await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()
-        assert DOMAIN in hass.config_entries.async_domains()
+        # The entry's own state, not `async_domains()`. That returns the
+        # domains of *registered* entries whatever state they are in, so
+        # it is true from `add_to_hass` onward -- including for a setup
+        # that raised `ConfigEntryNotReady` and left the entry retrying.
+        # Every test in the suite comes through here, so the guard being
+        # vacuous meant none of them checked that setup worked.
+        assert mock_config_entry.state is ConfigEntryState.LOADED
         return mock_config_entry
 
     return callback

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -280,14 +280,19 @@ async def test_a_unit_change_invalidates_the_held_setpoint(
         blocking=True,
     )
 
+    # 100 C rather than a value near the pre-flip setpoint: 121 C lands on
+    # 249.8 F, which rounds to the 250 this test started from, so a code
+    # path that wrongly kept the old data would have been indistinguishable
+    # from the right answer. 100 C is 212 F exactly, which is neither the
+    # stale held 300 nor the pre-flip 250.
     coordinator.async_set_updated_data(
-        {"moduleIsOn": True, "isFahrenheit": False, "grillSetTemp": 121}
+        {"moduleIsOn": True, "isFahrenheit": False, "grillSetTemp": 100}
     )
     await hass.async_block_till_done()
     state = hass.states.get(ENTITY_ID)
     assert state is not None
-    # 121 C converted for the imperial-unit test HA, not the stale 300.
-    assert state.attributes["temperature"] != 300.0
+    # 100 C converted for the imperial-unit test HA, not the stale 300.
+    assert state.attributes["temperature"] == 212.0
 
 
 @pytest.mark.parametrize("model", ["PBV4PS2"])

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -145,7 +145,6 @@ async def test_setup_entry_ble_connects_and_forwards_platforms(
         await hass.async_block_till_done()
 
     assert entry.state is ConfigEntryState.LOADED
-    assert DOMAIN in hass.config_entries.async_domains()
 
 
 async def test_setup_entry_local_connects_and_forwards_platforms(

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -382,13 +382,18 @@ async def test_a_unit_change_invalidates_the_held_target(
         blocking=True,
     )
 
+    # 90 C rather than 74: 74 C is 165.2 F, which renders as "165.0" once
+    # rounded to the step -- the same number as the stale held 165, which
+    # this could then only tell apart by its rendering. 90 C is 194 F, so
+    # the right answer and the wrong one are different numbers.
     coordinator.async_set_updated_data(
-        {"moduleIsOn": True, "isFahrenheit": False, "p2Target": 74}
+        {"moduleIsOn": True, "isFahrenheit": False, "p2Target": 90}
     )
     await hass.async_block_till_done()
     state = hass.states.get("number.mygrill_p2_target")
     assert state is not None
-    assert state.state != "165"
+    # 90 C converted for the imperial-unit test HA, not the stale 165.
+    assert float(state.state) == 194.0
 
 
 def _stored_target(entity_id: str, value: float, unit: str) -> tuple[State, dict]:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -89,6 +89,11 @@ async def test_recipe_sensors_absent_when_unsupported(
     mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
 ) -> None:
     await mock_add_config_entry()
+    # Anchored on a sensor PB2180LK does have. Absence alone passes if
+    # the platform never set up at all, or if an entity id is renamed --
+    # this is the only absence assertion in the suite without a sibling
+    # to hold it down.
+    assert hass.states.get("sensor.mygrill_probe_1") is not None
     assert hass.states.get("sensor.mygrill_recipe_time") is None
     assert hass.states.get("sensor.mygrill_recipe_step") is None
 


### PR DESCRIPTION
Found by auditing both suites for assertions that hold whether or not the behaviour they are named for does. Each finding below was confirmed by **breaking the production code and watching the old assertion pass** — not by reading.

## `mock_add_config_entry`'s guard (`tests/conftest.py`)

```py
assert DOMAIN in hass.config_entries.async_domains()
```

Reads as "setup succeeded". It is not. `async_domains()` returns the domains of *registered* entries whatever state they are in — no state filter at all — so it is true from `add_to_hass()` onward.

Forcing `async_setup_entry` to raise `ConfigEntryNotReady`: the fixture returned cleanly, entry in `SETUP_RETRY`. **Every test in the suite comes through this fixture.** Most survive only because they later index `hass.data[DOMAIN][entry.entry_id]`; the guard itself contributed nothing.

On `mock_config_entry.state is ConfigEntryState.LOADED`, the same mutation now fails 18 tests in `test_sensor.py` alone.

## `test_recipe_sensors_absent_when_unsupported`

Asserted only that two entities were absent — which is also exactly what a platform that never set up looks like. It passed with `sensor.async_setup_entry` stubbed to a no-op (the other 15 tests in the file failed), and would pass on any entity-id rename. It was the only unanchored absence assertion in the suite; every other one is paired with an `is not None` on a sibling. Now anchored on a sensor PB2180LK does have.

## The two unit-change tests

```py
assert state.attributes["temperature"] != 300.0   # climate
assert state.state != "165"                       # number
```

Both assert the *stale* value went away, never that the *correct* one arrived. Both passed with the entity returning `None`.

Naming the expected value meant changing the fixtures, because in both cases the right answer collided with a wrong one:

- **climate:** 121 °C is 249.8 °F, which rounds to the **250 the test starts from**. Asserting the correct value would not have distinguished converting the new data from wrongly keeping the old. Now 100 °C → 212 °F exactly, which is neither the stale 300 nor the pre-flip 250.
- **number:** 74 °C is 165.2 °F, which renders as `"165.0"` — the *same number* as the stale held 165, distinguishable only by rendering. That is why the original was `!= "165"`: had the pending path ever rendered as a float, the test would have passed while broken. Now 90 °C → 194 °F.

This one is worth dwelling on: the assertion was not merely weak, it was weak in a way that hid *why* it was weak.

## Also

Dropped the same vacuous `async_domains()` tail from `test_setup_entry_ble_connects_and_forwards_platforms`, where the `ConfigEntryState.LOADED` line above already carries the test.

## Verification

353 pass, `mypy .` clean, `ruff`/`ruff format` clean.

| Mutation | Old assertion | New assertion |
| --- | --- | --- |
| `async_setup_entry` raises `ConfigEntryNotReady` | passed | 18 failed |
| `sensor.async_setup_entry` stubbed to no-op | passed | fails |
| `GrillClimate.target_temperature` returns `None` | passed | fails |
| `TargetProbeTemperature.native_value` returns `None` | passed | fails |

Equivalent findings in pytboss — including `assert len(grills) > 0` as the entire test for `get_grills`'s control-board filter, which is the exact case REVIEW.md warns about — are going up separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)